### PR TITLE
fix: stabilize filter wizard synchronization

### DIFF
--- a/vue-frontend/src/components/FilterTabs.vue
+++ b/vue-frontend/src/components/FilterTabs.vue
@@ -378,7 +378,7 @@ import { usePropertiesStore } from '@/stores/properties'
 // 使用 requestOpenFullPanel 事件触发移动端的统一面板
 
 // 定义事件（在模板中通过 $emit 使用）
-// eslint-disable-next-line no-unused-vars
+ 
 const emit = defineEmits(['requestOpenFullPanel', 'searchSaved'])
 
 // 响应式状态

--- a/vue-frontend/src/components/FilterWizard.vue
+++ b/vue-frontend/src/components/FilterWizard.vue
@@ -305,7 +305,8 @@ const {
   nextStep,
   prevStep,
   applyFilters,
-  generateResultDescription
+  generateResultDescription,
+  restoreFromQuery
 } = useFilterWizard()
 
 // 面板引用
@@ -460,6 +461,7 @@ const handleKeyDown = (event) => {
 // 生命周期
 watch(visible, (newValue) => {
   if (newValue) {
+    restoreFromQuery()
     // 打开时聚焦到面板
     nextTick(() => {
       wizardRef.value?.focus()


### PR DESCRIPTION
## Summary
- normalize the filter wizard state around Pinia and the URL, adding postcode support, preserved sort syncing, and resilient preview counts
- trigger a wizard state refresh when opening the modal so the draft reflects the latest applied filters
- fall back gracefully when preview counts are unavailable in the mobile filter panel, updating the apply button semantics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d53ebafc832a8fe2fed46cbc5f27