### PR TITLE
fix(frontend): replace hard-coded colors with tokens

### DIFF
--- a/vue-frontend/src/components/AreasSelector.vue
+++ b/vue-frontend/src/components/AreasSelector.vue
@@ -405,7 +405,7 @@ watch(
 }
 
 .area-item:has(.check:checked) .area-name {
-  color: #374151;
+  color: var(--filter-color-text-primary);
   font-weight: 600;
 }
 
@@ -416,7 +416,7 @@ watch(
 }
 
 .area-item.selected .area-name {
-  color: #374151;
+  color: var(--filter-color-text-primary);
   font-weight: 600;
 }
 </style>

--- a/vue-frontend/src/components/FilterPanel.vue
+++ b/vue-frontend/src/components/FilterPanel.vue
@@ -1068,7 +1068,7 @@ onMounted(() => {
   right: 0;
   width: 420px;
   height: 100vh;
-  background: white;
+  background: var(--filter-panel-bg);
   box-shadow: -4px 0 20px rgb(0 0 0 / 15%);
   transform: translateX(100%);
   transition: transform 0.3s ease;
@@ -1202,7 +1202,7 @@ onMounted(() => {
 }
 
 .price-slider :deep(.el-slider__runway) {
-  background-color: #e5e7eb;
+  background-color: var(--filter-color-neutral-200);
   height: 6px;
 }
 
@@ -1213,7 +1213,7 @@ onMounted(() => {
 
 .price-slider :deep(.el-slider__button) {
   border: 3px solid var(--color-border-strong);
-  background-color: white;
+  background-color: var(--filter-color-bg-primary);
   width: 20px;
   height: 20px;
 }
@@ -1362,7 +1362,7 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 16px;
-  background: #f8f9fa;
+  background: var(--filter-color-bg-muted);
   border: 1px solid var(--color-border-default);
   border-radius: 8px;
 }
@@ -1760,7 +1760,7 @@ onMounted(() => {
 
     /* 为 iOS 底部 Home Bar 预留安全区，确保按钮不被遮挡 */
     padding-bottom: calc(20px + env(safe-area-inset-bottom));
-    background: white;
+    background: var(--color-bg-card);
 
     /* 说明：footer 位于滚动容器(panel-content)之外，天然常驻，无需 sticky；此处仅做安全区留白 */
   }

--- a/vue-frontend/src/components/GoogleMap.vue
+++ b/vue-frontend/src/components/GoogleMap.vue
@@ -28,6 +28,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted, watch, nextTick, computed } from 'vue'
 import { Loading, Location } from '@element-plus/icons-vue'
+import { getCssVarValue } from '@/utils/designTokens'
 
 const props = defineProps({
   latitude: {
@@ -73,7 +74,6 @@ const props = defineProps({
   routeOptions: {
     type: Object,
     default: () => ({
-      strokeColor: '#4285F4',
       strokeOpacity: 0.9,
       strokeWeight: 5,
       zIndex: 999,
@@ -116,6 +116,31 @@ let lastRoutePath = null // 记录最近一次路线点列，便于 resize 重�
 let isFitting = false // 正在执行 fitBounds，避免与锁定中心冲突
 let resizeTimer = null // 节流 resize
 let routeLabelInfoWindow = null // 路线标签 InfoWindow 实例
+
+const mergedRouteOptions = computed(() => {
+  const fallbackColor = getCssVarValue('--juwo-primary', '#0057ff')
+  const baseOptions = {
+    strokeColor: fallbackColor,
+    strokeOpacity: 0.9,
+    strokeWeight: 5,
+    zIndex: 999,
+  }
+
+  if (!props.routeOptions) {
+    return baseOptions
+  }
+
+  const providedColor =
+    typeof props.routeOptions.strokeColor === 'string'
+      ? props.routeOptions.strokeColor.trim()
+      : props.routeOptions.strokeColor
+
+  return {
+    ...baseOptions,
+    ...props.routeOptions,
+    strokeColor: providedColor ? providedColor : fallbackColor,
+  }
+})
 
 // 数值校验与经纬度规范化：兼容字符串输入并过滤 NaN/Infinity
 const isFiniteNumber = (n) => typeof n === 'number' && Number.isFinite(n)
@@ -312,7 +337,7 @@ const renderRoute = () => {
   if (!path || path.length < 2) return
   polyline = new google.maps.Polyline({
     path,
-    ...props.routeOptions,
+    ...mergedRouteOptions.value,
     map,
   })
   // 记录并自动自适应视野
@@ -538,7 +563,7 @@ watch(
 )
 
 watch(
-  () => props.routeOptions,
+  mergedRouteOptions,
   () => {
     renderRoute()
   },
@@ -659,7 +684,7 @@ onUnmounted(() => {
 .google-map {
   width: 100%;
   height: v-bind(height);
-  background-color: #f5f5f5;
+  background-color: var(--surface-2);
   position: relative;
 }
 
@@ -672,7 +697,7 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   gap: 8px;
-  color: #999;
+  color: var(--text-muted);
 }
 
 .map-loading span {
@@ -683,7 +708,7 @@ onUnmounted(() => {
 .map-fallback {
   width: 100%;
   height: v-bind(height);
-  background-color: #f5f5f5;
+  background-color: var(--surface-2);
   position: relative;
   display: flex;
   align-items: center;
@@ -709,7 +734,7 @@ onUnmounted(() => {
   align-items: center;
   gap: 6px;
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
 }
 </style>

--- a/vue-frontend/src/components/MarkdownContent.vue
+++ b/vue-frontend/src/components/MarkdownContent.vue
@@ -82,7 +82,7 @@ const sanitizedHtml = computed(() => {
 .markdown-content {
   font-size: 14px;
   line-height: 1.8;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .markdown-content :deep(p) {
@@ -96,7 +96,7 @@ const sanitizedHtml = computed(() => {
 .markdown-content :deep(strong),
 .markdown-content :deep(b) {
   font-weight: 600;
-  color: #111;
+  color: var(--color-text-primary);
 }
 
 .markdown-content :deep(ul),
@@ -121,7 +121,7 @@ const sanitizedHtml = computed(() => {
 .markdown-content :deep(h5),
 .markdown-content :deep(h6) {
   font-weight: 600;
-  color: #111;
+  color: var(--color-text-primary);
   margin: 16px 0 8px;
   line-height: 1.3;
 }
@@ -153,13 +153,13 @@ const sanitizedHtml = computed(() => {
 .markdown-content :deep(blockquote) {
   margin: 12px 0;
   padding: 8px 16px;
-  border-left: 3px solid #007bff;
-  background-color: #f8f9fa;
-  color: #555;
+  border-left: 3px solid var(--juwo-primary);
+  background-color: var(--filter-color-bg-secondary);
+  color: var(--color-text-secondary);
 }
 
 .markdown-content :deep(pre) {
-  background-color: #f5f5f5;
+  background-color: var(--surface-2);
   padding: 12px;
   border-radius: 4px;
   overflow-x: auto;
@@ -167,7 +167,7 @@ const sanitizedHtml = computed(() => {
 }
 
 .markdown-content :deep(code) {
-  background-color: #f5f5f5;
+  background-color: var(--surface-2);
   padding: 2px 6px;
   border-radius: 3px;
   font-family: Consolas, Monaco, monospace;
@@ -177,15 +177,16 @@ const sanitizedHtml = computed(() => {
 .markdown-content :deep(hr) {
   margin: 16px 0;
   border: none;
-  border-top: 1px solid #e5e5e5;
+  border-top: 1px solid var(--color-border-default);
 }
 
 .markdown-content :deep(a) {
-  color: #007bff;
+  color: var(--link-color);
   text-decoration: none;
 }
 
 .markdown-content :deep(a:hover) {
+  color: var(--link-hover-color);
   text-decoration: underline;
 }
 </style>

--- a/vue-frontend/src/components/PropertyCard.vue
+++ b/vue-frontend/src/components/PropertyCard.vue
@@ -130,6 +130,7 @@ import { ref, computed, inject, onMounted, onUnmounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { BedDouble, Bath, CarFront, Star, MoreHorizontal, Share2, EyeOff } from 'lucide-vue-next' // 导入 Lucide 图标
 import { usePropertiesStore } from '@/stores/properties'
+import { getCssVarValue } from '@/utils/designTokens'
 
 const t = inject('t')
 
@@ -183,7 +184,9 @@ const validImages = computed(() => {
 })
 
 const placeholderImage = computed(() => {
-  const placeholderSvg = `<svg width="580" height="386" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#f3f4f6"/><text x="50%" y="50%" font-family="Inter, sans-serif" font-size="18" dy=".3em" fill="#9ca3af" text-anchor="middle">${t('propertyCard.imageAlt')}</text></svg>`
+  const background = getCssVarValue('--filter-color-neutral-100', '#f3f4f6')
+  const foreground = getCssVarValue('--filter-color-neutral-400', '#9ca3af')
+  const placeholderSvg = `<svg width="580" height="386" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="${background}"/><text x="50%" y="50%" font-family="Inter, sans-serif" font-size="18" dy=".3em" fill="${foreground}" text-anchor="middle">${t('propertyCard.imageAlt')}</text></svg>`
   return `data:image/svg+xml,${encodeURIComponent(placeholderSvg)}`
 })
 

--- a/vue-frontend/src/components/SearchOverlay.vue
+++ b/vue-frontend/src/components/SearchOverlay.vue
@@ -516,7 +516,7 @@ watch(
 .pill.selected {
   background: var(--juwo-primary);
   border-color: var(--juwo-primary);
-  color: #fff;
+  color: var(--filter-btn-primary-color);
 }
 
 .pill-icon {

--- a/vue-frontend/src/components/SimpleMap.vue
+++ b/vue-frontend/src/components/SimpleMap.vue
@@ -15,7 +15,7 @@
     <!-- 备用：显示静态地址信息 -->
     <div v-else class="map-static">
       <div class="map-icon">
-        <el-icon :size="48" color="#FF5824"><Location /></el-icon>
+        <el-icon :size="48" class="map-icon-symbol"><Location /></el-icon>
       </div>
       <div class="map-info">
         <h4>{{ markerTitle }}</h4>
@@ -89,7 +89,7 @@ const formattedCoordinates = computed(() => {
   height: v-bind(height);
   border-radius: 8px;
   overflow: hidden;
-  background-color: #f5f5f5;
+  background-color: var(--surface-2);
 }
 
 .map-iframe {
@@ -107,22 +107,27 @@ const formattedCoordinates = computed(() => {
   justify-content: center;
   padding: 20px;
   text-align: center;
-  background: linear-gradient(135deg, #f5f5f5 0%, #e8e8e8 100%);
+  background: linear-gradient(135deg, var(--surface-2) 0%, var(--surface-4) 100%);
 }
 
 .map-icon {
   margin-bottom: 16px;
 }
 
+.map-icon :deep(.el-icon),
+.map-icon :deep(svg) {
+  color: var(--juwo-primary);
+}
+
 .map-info h4 {
   margin: 0 0 8px;
   font-size: 16px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .map-info p {
   margin: 0;
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 </style>

--- a/vue-frontend/src/components/base/BaseButton.vue
+++ b/vue-frontend/src/components/base/BaseButton.vue
@@ -198,7 +198,7 @@ const handleClick = (event) => {
 /* 危险按钮 */
 .base-button--danger {
   background: var(--filter-color-danger);
-  color: #fff;
+  color: var(--filter-btn-primary-color);
   border-color: var(--filter-color-danger);
 }
 

--- a/vue-frontend/src/components/commute/TransportModes.vue
+++ b/vue-frontend/src/components/commute/TransportModes.vue
@@ -58,8 +58,8 @@ const selectMode = (value) => {
   height: 48px;
   border-radius: 50%;
   border: none;
-  background: #f5f5f5;
-  color: #666;
+  background: var(--surface-2);
+  color: var(--color-text-secondary);
   font-size: 18px;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -91,7 +91,7 @@ const selectMode = (value) => {
 }
 
 .mode-btn:hover {
-  background: #ebebeb;
+  background: var(--surface-3);
 }
 
 .mode-btn:active {
@@ -99,12 +99,12 @@ const selectMode = (value) => {
 }
 
 .mode-btn.active {
-  background: #333;
-  color: white;
+  background: var(--filter-color-neutral-800);
+  color: var(--color-text-inverse);
 }
 
 .mode-btn.active:hover {
-  background: #222;
+  background: var(--filter-color-neutral-900);
 }
 
 /* 触摸设备优化 */
@@ -115,11 +115,11 @@ const selectMode = (value) => {
   }
 
   .mode-btn:hover {
-    background: #f5f5f5;
+    background: var(--surface-2);
   }
 
   .mode-btn.active:hover {
-    background: #333;
+    background: var(--filter-color-neutral-800);
   }
 }
 </style>

--- a/vue-frontend/src/components/modals/AuthModal.vue
+++ b/vue-frontend/src/components/modals/AuthModal.vue
@@ -225,9 +225,9 @@ const handleFacebookAuth = () => {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: white;
+  background: var(--color-bg-card);
   padding: 20px;
-  border-bottom: 1px solid #e3e3e3;
+  border-bottom: 1px solid var(--color-border-default);
   display: flex;
   align-items: center;
   gap: 16px;
@@ -238,7 +238,7 @@ const handleFacebookAuth = () => {
   height: 32px;
   border: none;
   background: none;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 20px;
   cursor: pointer;
   display: flex;
@@ -249,13 +249,13 @@ const handleFacebookAuth = () => {
 }
 
 .close-btn:hover {
-  background: #f5f5f5;
+  background: var(--surface-2);
 }
 
 .modal-title {
   font-size: 20px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin: 0;
 }
 
@@ -275,7 +275,7 @@ const handleFacebookAuth = () => {
 .auth-form :deep(.el-form-item__label) {
   font-size: 14px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 8px;
 }
 
@@ -291,24 +291,24 @@ const handleFacebookAuth = () => {
   font-weight: 600;
   border-radius: 8px;
   margin-top: 24px;
-  background: #dc2626 !important;
-  border-color: #dc2626 !important;
+  background: var(--filter-color-danger) !important;
+  border-color: var(--filter-color-danger) !important;
 }
 
 .submit-btn:hover {
-  background: #b91c1c !important;
-  border-color: #b91c1c !important;
+  background: var(--filter-color-danger-hover) !important;
+  border-color: var(--filter-color-danger-hover) !important;
 }
 
 .switch-mode {
   text-align: center;
   margin: 24px 0;
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
 }
 
 .switch-link {
-  color: #dc2626;
+  color: var(--filter-color-danger);
   cursor: pointer;
   font-weight: 600;
   margin-left: 4px;
@@ -326,9 +326,9 @@ const handleFacebookAuth = () => {
 }
 
 .divider span {
-  background: white;
+  background: var(--color-bg-card);
   padding: 0 16px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 14px;
   position: relative;
   z-index: 1;
@@ -341,7 +341,7 @@ const handleFacebookAuth = () => {
   top: 50%;
   width: 100%;
   height: 1px;
-  background: #e3e3e3;
+  background: var(--color-border-default);
 }
 
 .social-buttons {
@@ -352,9 +352,9 @@ const handleFacebookAuth = () => {
 .social-btn {
   flex: 1;
   height: 48px;
-  border: 1px solid #e3e3e3;
+  border: 1px solid var(--color-border-default);
   border-radius: 8px;
-  background: white;
+  background: var(--color-bg-card);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -362,13 +362,13 @@ const handleFacebookAuth = () => {
   gap: 8px;
   font-size: 14px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   transition: all 0.2s;
 }
 
 .social-btn:hover {
-  background: #f5f5f5;
-  border-color: #d0d0d0;
+  background: var(--surface-2);
+  border-color: var(--filter-color-border-strong);
 }
 
 .social-btn i {
@@ -376,11 +376,11 @@ const handleFacebookAuth = () => {
 }
 
 .google-btn i {
-  color: #ea4335;
+  color: var(--brand-google);
 }
 
 .facebook-btn i {
-  color: #1877f2;
+  color: var(--brand-facebook);
 }
 
 /* Mobile optimization */

--- a/vue-frontend/src/components/modals/EmailVerifyModal.vue
+++ b/vue-frontend/src/components/modals/EmailVerifyModal.vue
@@ -208,9 +208,9 @@ onUnmounted(() => {
   position: sticky;
   top: 0;
   z-index: 100;
-  background: white;
+  background: var(--color-bg-card);
   padding: 20px;
-  border-bottom: 1px solid #e3e3e3;
+  border-bottom: 1px solid var(--color-border-default);
   display: flex;
   align-items: center;
   gap: 16px;
@@ -221,7 +221,7 @@ onUnmounted(() => {
   height: 32px;
   border: none;
   background: none;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 18px;
   cursor: pointer;
   display: flex;
@@ -232,13 +232,13 @@ onUnmounted(() => {
 }
 
 .back-btn:hover {
-  background: #f5f5f5;
+  background: var(--surface-2);
 }
 
 .modal-title {
   font-size: 20px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin: 0;
 }
 
@@ -255,7 +255,7 @@ onUnmounted(() => {
 .verify-icon {
   width: 80px;
   height: 80px;
-  background: #fef3c7;
+  background: var(--semantic-warning-weak);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -265,35 +265,35 @@ onUnmounted(() => {
 
 .verify-icon i {
   font-size: 40px;
-  color: #f59e0b;
+  color: var(--semantic-warning);
 }
 
 .verify-title {
   font-size: 24px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 16px;
 }
 
 .verify-description {
   font-size: 16px;
-  color: #666;
+  color: var(--color-text-secondary);
   margin-bottom: 12px;
 }
 
 .email-display {
   font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   padding: 12px 16px;
-  background: #f5f5f5;
+  background: var(--surface-2);
   border-radius: 8px;
   margin-bottom: 16px;
 }
 
 .verify-instructions {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   line-height: 1.5;
   margin-bottom: 32px;
 }
@@ -316,7 +316,7 @@ onUnmounted(() => {
 .resend-link {
   background: none;
   border: none;
-  color: #dc2626;
+  color: var(--filter-color-danger);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;
@@ -328,13 +328,13 @@ onUnmounted(() => {
 }
 
 .resend-link:disabled {
-  color: #999;
+  color: var(--text-muted);
   cursor: not-allowed;
 }
 
 .divider {
   height: 1px;
-  background: #e3e3e3;
+  background: var(--color-border-default);
   margin: 32px 0;
 }
 
@@ -345,7 +345,7 @@ onUnmounted(() => {
 .help-section h4 {
   font-size: 16px;
   font-weight: 600;
-  color: #333;
+  color: var(--color-text-primary);
   margin-bottom: 12px;
 }
 
@@ -357,7 +357,7 @@ onUnmounted(() => {
 
 .help-list li {
   font-size: 14px;
-  color: #666;
+  color: var(--color-text-secondary);
   padding: 8px 0;
   padding-left: 20px;
   position: relative;
@@ -367,7 +367,7 @@ onUnmounted(() => {
   content: '•';
   position: absolute;
   left: 0;
-  color: #999;
+  color: var(--text-muted);
 }
 
 /* Mobile optimization */

--- a/vue-frontend/src/utils/designTokens.js
+++ b/vue-frontend/src/utils/designTokens.js
@@ -1,0 +1,12 @@
+export const getCssVarValue = (name, fallback = '') => {
+  if (!name) {
+    return fallback
+  }
+
+  if (typeof window === 'undefined' || !window.document?.documentElement) {
+    return fallback
+  }
+
+  const value = getComputedStyle(document.documentElement).getPropertyValue(name)
+  return value && value.trim() ? value.trim() : fallback
+}

--- a/vue-frontend/src/views/ChatView.vue
+++ b/vue-frontend/src/views/ChatView.vue
@@ -9,7 +9,7 @@
 
         <div class="chat-content">
           <div class="placeholder-content">
-            <el-icon :size="64" color="#d9d9d9">
+            <el-icon :size="64" class="placeholder-icon">
               <ChatDotRound />
             </el-icon>
             <h3 class="chinese-text">AI助手功能开发中</h3>
@@ -66,7 +66,7 @@ const goToHome = () => {
 }
 
 .chat-content {
-  background: white;
+  background: var(--color-bg-card);
   padding: 40px;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
@@ -79,6 +79,10 @@ const goToHome = () => {
 .placeholder-content {
   text-align: center;
   max-width: 400px;
+}
+
+.placeholder-icon {
+  color: var(--filter-color-neutral-300);
 }
 
 .placeholder-content h3 {

--- a/vue-frontend/src/views/Favorites.vue
+++ b/vue-frontend/src/views/Favorites.vue
@@ -12,7 +12,7 @@
         <div class="favorites-section">
           <!-- 空状态 -->
           <div v-if="favoriteProperties.length === 0" class="empty-state">
-            <el-icon :size="64" color="#d9d9d9">
+            <el-icon :size="64" class="empty-icon-symbol">
               <Star />
             </el-icon>
             <h3 class="chinese-text">还没有收藏的房源</h3>
@@ -139,6 +139,10 @@ const handleContactProperty = (property) => {
   padding: 80px 20px;
   gap: 16px;
   text-align: center;
+}
+
+.empty-icon-symbol {
+  color: var(--filter-color-neutral-300);
 }
 
 .empty-state h3 {

--- a/vue-frontend/src/views/HomeView.vue
+++ b/vue-frontend/src/views/HomeView.vue
@@ -606,7 +606,7 @@ onUnmounted(() => {
 .search-filter-section {
   /* 从一开始就横贯整个屏幕，像Domain一样 */
   width: 100%;
-  background: white;
+  background: var(--color-bg-card);
   box-shadow: 0 2px 8px rgb(0 0 0 / 6%);
   margin-bottom: 16px; /* 减少移动端下边距 */
   z-index: 50;
@@ -717,7 +717,7 @@ onUnmounted(() => {
   gap: 2px; /* 图标与文字更紧凑 */
   border: 1px solid var(--color-border-default);
   border-radius: 9999px; /* 强制药丸型 */
-  background: #fff;
+  background: var(--color-bg-card);
   color: var(--color-text-secondary);
   font-weight: 500;
   font-size: 13px;
@@ -727,7 +727,7 @@ onUnmounted(() => {
 .filter-trigger-btn:hover {
   border-color: var(--color-border-strong);
   color: var(--color-text-primary);
-  background: #f7f8fa;
+  background: var(--el-color-primary-light-9);
 }
 
 .filter-trigger-btn:focus {

--- a/vue-frontend/src/views/MapView.vue
+++ b/vue-frontend/src/views/MapView.vue
@@ -9,7 +9,7 @@
 
         <div class="map-content">
           <div class="placeholder-content">
-            <el-icon :size="64" color="#d9d9d9">
+            <el-icon :size="64" class="placeholder-icon">
               <MapLocation />
             </el-icon>
             <h3 class="chinese-text">地图功能开发中</h3>
@@ -66,7 +66,7 @@ const goToHome = () => {
 }
 
 .map-content {
-  background: white;
+  background: var(--color-bg-card);
   padding: 40px;
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-sm);
@@ -79,6 +79,10 @@ const goToHome = () => {
 .placeholder-content {
   text-align: center;
   max-width: 400px;
+}
+
+.placeholder-icon {
+  color: var(--filter-color-neutral-300);
 }
 
 .placeholder-content h3 {


### PR DESCRIPTION
## Summary
- replace remaining hard-coded color values across components and views with existing design tokens
- add a utility helper to read CSS variable values for SVG placeholders and Google Maps routes
- refresh placeholder styling and map fallbacks to match the neutral/brand palette consistently

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cde458ac8c832a9b3a49879eee3d26