### PR TITLE
fix: repair profile interactions

### DIFF
--- a/vue-frontend/src/components/PropertyCard.vue
+++ b/vue-frontend/src/components/PropertyCard.vue
@@ -293,7 +293,7 @@ const handleCardClick = () => {
 }
 
 const toggleFavorite = () => {
-  propertiesStore.toggleFavorite(props.property.listing_id)
+  propertiesStore.toggleFavorite(props.property)
 }
 
 // 处理更多操作菜单
@@ -314,7 +314,8 @@ const handleMoreAction = (command) => {
 <style scoped>
 /* 房源卡片样式 - 复用现有设计 */
 .property-card {
-  width: 580px;
+  width: 100%;
+  max-width: 580px;
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-default);
   border-radius: 6px;

--- a/vue-frontend/src/composables/useFilterWizard.js
+++ b/vue-frontend/src/composables/useFilterWizard.js
@@ -491,11 +491,16 @@ export function useFilterWizard() {
 
       const params = savedSearch.filterParams ? { ...savedSearch.filterParams } : buildFilterParams()
       await propertiesStore.applyFilters(params)
-      await syncRouterQuery(params)
-      return true
+      const appliedQuery = sanitizeQueryParams(
+        propertiesStore.currentFilterParams && Object.keys(propertiesStore.currentFilterParams).length
+          ? propertiesStore.currentFilterParams
+          : params,
+      )
+      await syncRouterQuery(appliedQuery)
+      return appliedQuery
     } catch (error) {
       console.error('应用已保存搜索失败:', error)
-      return false
+      return null
     }
   }
 

--- a/vue-frontend/src/views/PropertyDetail.vue
+++ b/vue-frontend/src/views/PropertyDetail.vue
@@ -517,7 +517,7 @@ const toggleFavorite = () => {
     propertiesStore.removeFavorite(property.value.listing_id)
     ElMessage.success('已从收藏中移除')
   } else {
-    propertiesStore.addFavorite(property.value.listing_id)
+    propertiesStore.addFavorite(property.value)
     ElMessage.success('已添加到收藏')
   }
 }
@@ -745,8 +745,10 @@ onMounted(async () => {
   // 预加载下一张图片
   if (property.value) {
     preloadNextImage()
+    propertiesStore.addHistory(property.value)
+  } else {
+    propertiesStore.logHistory(propertyId)
   }
-  propertiesStore.logHistory(propertyId)
 })
 
 onBeforeRouteLeave(() => {


### PR DESCRIPTION
## Summary
- ensure profile cards navigate to detail pages, keep favorite data fresh, and sync saved-search counts via manager events
- normalise favorite/history persistence in the properties store and card/detail interactions so full property objects are retained
- return applied query params when reusing saved searches and navigate home with those filters while keeping the cards responsive

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d08ae55270832aa8c9a91dc8afdbba