### PR TITLE
fix(frontend): align profile toolbar actions

### DIFF
--- a/vue-frontend/src/views/Profile.vue
+++ b/vue-frontend/src/views/Profile.vue
@@ -1,23 +1,23 @@
 <template>
   <div class="page profile-page">
     <!-- 1. 页面头部: 完全遵循样板和视觉标准 -->
-    <header class="page__header header-with-actions">
+    <header class="page__header header-with-back">
       <!-- 返回上一页（无历史则回首页） -->
       <BaseIconButton aria-label="返回上一页" @click="goBack">
         <ArrowLeft />
       </BaseIconButton>
 
       <h1 class="typo-h1 page-title">{{ pageTitle }}</h1>
-
-      <!-- 回到首页 -->
-      <router-link to="/">
-        <BaseButton variant="ghost" aria-label="回到首页">回到首页</BaseButton>
-      </router-link>
     </header>
 
-    <!-- 账号操作：退出登录（次要按钮样式） -->
-    <section class="page-section account-actions">
-      <BaseButton variant="secondary" @click="handleLogout">退出登录</BaseButton>
+    <!-- 页面操作区：回到首页、退出登录 -->
+    <section class="page__toolbar account-toolbar" aria-label="页面操作">
+      <div class="account-toolbar__actions">
+        <router-link to="/" class="account-toolbar__link">
+          <BaseButton variant="ghost" aria-label="回到首页">回到首页</BaseButton>
+        </router-link>
+        <BaseButton variant="secondary" @click="handleLogout">退出登录</BaseButton>
+      </div>
     </section>
 
     <!-- 2. 页面内容区 -->
@@ -210,8 +210,9 @@ onMounted(() => {
   }
 }
 
-.empty-state, .placeholder-state {
-  padding: var(--space-8) var(--space-4);
+.empty-state,
+.placeholder-state {
+  padding: var(--space-xl) var(--space-4);
   background-color: var(--color-bg-card);
   border: 1px dashed var(--color-border-default);
   border-radius: var(--radius-md);
@@ -222,62 +223,29 @@ onMounted(() => {
   color: var(--color-text-secondary);
 }
 
-.header-with-actions {
+.header-with-back {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: var(--space-3);
 }
 
-.header-with-actions .page-title {
-  flex: 1;
-  text-align: center;
+.header-with-back .page-title {
   margin: 0;
 }
 
-/* 统一图标按钮样式（令牌化） */
-.icon-btn {
-  background: transparent;
-  border: 1px solid var(--color-border-default);
-  color: var(--color-text-secondary);
-  width: 36px;
-  height: 36px;
-  border-radius: 18px;
-  display: inline-flex;
+.account-toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.account-toolbar__actions {
+  display: flex;
   align-items: center;
-  justify-content: center;
-  padding: 0;
-  cursor: pointer;
-  transition: background-color .2s ease, color .2s ease, transform .1s ease;
+  gap: var(--space-3);
 }
 
-.icon-btn:hover {
-  background: var(--bg-hover);
-  color: var(--color-text-primary);
-}
-
-.icon-btn:active {
-  transform: translateY(1px);
-}
-
-.icon-btn .icon {
-  width: 18px;
-  height: 18px;
-}
-
-/* 账号操作区与标题之间的节奏 */
-.account-actions {
-  padding-top: 0;
-  margin-top: 8px;
-  margin-bottom: var(--page-section-gap, 24px);
-}
-
-/* 适配移动端：保证左右控件可点区域充足 */
-@media (width <= 767px) {
-  .icon-btn {
-    width: 40px;
-    height: 40px;
-    border-radius: 20px;
-  }
+.account-toolbar__link {
+  display: inline-flex;
+  text-decoration: none;
 }
 </style>


### PR DESCRIPTION
## Summary
- move the profile view's home and logout buttons into a shared toolbar so the actions align visually
- apply design token spacing to the header and toolbar wrappers to match the page scaffold rhythm

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd4d6dcd6c832abeb67a42a80234d3