### PR TITLE
refactor(tokens): add area selector component tokens

### DIFF
--- a/CODE_REVIEW_RULES.md
+++ b/CODE_REVIEW_RULES.md
@@ -19,7 +19,7 @@
   4) 模板/脚本内联颜色样式：
      - `<div :style="{ color: '#2563eb' }">` / `style="border: 1px solid #e5e7eb"`
   5) 使用非规范变量名：
-     - 允许前缀：`--juwo-* | --link-* | --color-* | --text-* | --bg-* | --border-* | --space-* | --radius-* | --shadow-* | --brand-* | --filter-*`
+     - 允许前缀：`--juwo-* | --link-* | --color-* | --text-* | --bg-* | --border-* | --space-* | --radius-* | --shadow-* | --brand-* | --button-* | --chip-* | --panel-* | --list-item-* | --search-* | --clear-* | --checkbox-* | --filter-field-*`
      - 其它自造全局变量名一律拒绝（局部作用域变量例外，但不建议）
 
 ---
@@ -32,7 +32,7 @@
   - 背景：`--color-bg-page | --color-bg-card | --bg-hover`
   - 边框：`--color-border-default | --color-border-strong`
   - 焦点/滚动：`--focus-ring-* | --neutral-scrollbar-*`
-  - 筛选域：`--filter-*`（仅筛选面板域）
+  - 筛选域：`--panel-* / --chip-* / --list-item-* / --search-* / --filter-field-*`（仅筛选面板域）
 - 变更说明：PR 描述必须包含“前端表现”段落（示例见第 5 节模板）
 - 渐进式：修改现有文件时，遵循 **童子军军规**（见第 4 节）；范围内顺手替换 1–3 处硬编码为 Token，小步提交。
 - 向后兼容：若 Token 更名或切换值会影响大范围，采用“旧名 → 新值”的别名过渡，待稳定后再清理。

--- a/vue-frontend/src/components/AreasSelector.vue
+++ b/vue-frontend/src/components/AreasSelector.vue
@@ -252,7 +252,7 @@ watch(
 .search-icon {
   position: absolute;
   left: 12px;
-  color: var(--filter-color-text-secondary);
+  color: var(--color-text-secondary);
   pointer-events: none;
   z-index: 1;
 }
@@ -262,20 +262,20 @@ watch(
   padding: 12px 16px 12px 40px;
   font-size: 14px;
   color: var(--color-text-primary);
-  background: var(--filter-color-bg-primary);
-  border: 1px solid var(--filter-color-border-default);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-default);
   border-radius: 6px;
   outline: none;
   transition: all 0.2s ease;
 }
 
 .areas-search:focus {
-  border-color: var(--filter-search-focus-border);
-  box-shadow: var(--filter-shadow-focus);
+  border-color: var(--search-focus-border);
+  box-shadow: var(--shadow-focus);
 }
 
 .areas-search:hover:not(:focus) {
-  border-color: var(--filter-search-hover-border);
+  border-color: var(--search-hover-border);
 }
 
 .clear-search-btn {
@@ -294,8 +294,8 @@ watch(
 }
 
 .clear-search-btn:hover {
-  background: var(--filter-color-hover-bg);
-  color: var(--filter-color-text-primary);
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
 }
 
 .clear-all-btn {
@@ -303,9 +303,9 @@ watch(
   padding: 12px 16px;
   font-size: 14px;
   font-weight: 500;
-  background: var(--filter-color-bg-primary);
-  color: var(--filter-color-text-secondary);
-  border: 1px solid var(--filter-color-border-default);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-default);
   border-radius: 6px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -313,34 +313,34 @@ watch(
 }
 
 .clear-all-btn:hover:not(:disabled) {
-  background: var(--filter-color-bg-secondary);
-  color: var(--filter-color-text-primary);
-  border-color: var(--filter-color-border-strong);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border-strong);
 }
 
 .clear-all-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
-  background: var(--filter-color-bg-secondary);
+  background: var(--color-bg-secondary);
 }
 
 .areas-body {
-  max-height: 280px;
+  max-height: var(--areas-body-max-height);
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   border: none; /* 简化：移除外框横线 */
-  border-radius: 6px;
-  background: var(--filter-color-bg-primary);
+  border-radius: var(--areas-body-radius);
+  background: var(--areas-body-bg);
 }
 
 .loading-row,
 .empty-row {
-  padding: 20px 16px;
-  font-size: 14px;
+  padding: var(--areas-state-padding-y) var(--areas-state-padding-x);
+  font-size: var(--areas-state-font-size);
   color: var(--color-text-secondary);
-  background: var(--filter-color-bg-secondary);
+  background: var(--color-bg-secondary);
   text-align: center;
-  border-radius: 6px;
+  border-radius: var(--areas-state-radius);
 }
 
 
@@ -364,24 +364,24 @@ watch(
 }
 
 .area-item:hover {
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .area-row {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 14px 16px;
+  gap: var(--areas-row-gap);
+  padding: var(--areas-row-padding-y) var(--areas-row-padding-x);
   cursor: pointer;
   transition: all 0.15s ease;
-  min-height: 48px;
+  min-height: var(--areas-row-min-height);
 }
 
 .check {
-  width: 18px;
-  height: 18px;
-  border-radius: 3px;
-  accent-color: var(--filter-checkbox-accent);
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  border-radius: var(--checkbox-radius);
+  accent-color: var(--checkbox-accent);
   cursor: pointer;
   transition: transform 0.15s ease;
 }
@@ -391,32 +391,32 @@ watch(
 }
 
 .area-name {
-  font-size: 14px;
+  font-size: var(--areas-name-font-size);
   color: var(--color-text-primary);
   user-select: none;
-  line-height: 1.4;
+  line-height: var(--areas-name-line-height);
   flex: 1;
 }
 
 /* 选中状态的行样式 */
 .area-item:has(.check:checked) {
-  background: var(--filter-color-selected-bg);
-  border-color: var(--filter-color-selected-border);
+  background: var(--color-selected-bg);
+  border-color: var(--color-selected-border);
 }
 
 .area-item:has(.check:checked) .area-name {
-  color: var(--filter-color-text-primary);
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--areas-name-font-weight-selected);
 }
 
 /* 如果浏览器不支持 :has，使用 JavaScript 类名回退 */
 .area-item.selected {
-  background: var(--filter-color-selected-bg);
-  border-color: var(--filter-color-selected-border);
+  background: var(--color-selected-bg);
+  border-color: var(--color-selected-border);
 }
 
 .area-item.selected .area-name {
-  color: var(--filter-color-text-primary);
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--areas-name-font-weight-selected);
 }
 </style>

--- a/vue-frontend/src/components/FilterPanel.vue
+++ b/vue-frontend/src/components/FilterPanel.vue
@@ -1068,7 +1068,7 @@ onMounted(() => {
   right: 0;
   width: 420px;
   height: 100vh;
-  background: var(--filter-panel-bg);
+  background: var(--panel-bg);
   box-shadow: -4px 0 20px rgb(0 0 0 / 15%);
   transform: translateX(100%);
   transition: transform 0.3s ease;
@@ -1086,36 +1086,36 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--filter-space-2xl) var(--filter-space-3xl);
-  border-bottom: 1px solid var(--filter-panel-header-border);
-  background: var(--filter-panel-bg);
+  padding: var(--space-xl) var(--space-2xl);
+  border-bottom: 1px solid var(--panel-header-border);
+  background: var(--panel-bg);
 }
 
 .panel-title {
-  font-size: var(--filter-panel-title-font-size);
-  font-weight: var(--filter-panel-title-font-weight);
-  color: var(--filter-panel-title-color);
+  font-size: var(--panel-title-font-size);
+  font-weight: var(--panel-title-font-weight);
+  color: var(--panel-title-color);
   margin: 0;
-  line-height: var(--filter-line-height-tight);
+  line-height: var(--line-height-tight);
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: var(--filter-space-xl);
+  gap: var(--space-lg);
 }
 
 .reset-link {
   background: none;
   border: none;
-  color: var(--filter-action-link-color);
-  font-size: var(--filter-action-link-font-size);
-  font-weight: var(--filter-action-link-font-weight);
+  color: var(--panel-action-link-color);
+  font-size: var(--panel-action-link-font-size);
+  font-weight: var(--panel-action-link-font-weight);
   cursor: pointer;
   text-decoration: underline;
-  padding: var(--filter-action-link-padding-y) var(--filter-action-link-padding-x);
-  border-radius: var(--filter-action-link-radius);
-  transition: var(--filter-transition-fast);
+  padding: var(--panel-action-link-padding-y) var(--panel-action-link-padding-x);
+  border-radius: var(--panel-action-link-radius);
+  transition: var(--transition-fast);
 
   /* 移动端触摸目标 */
   min-height: 32px;
@@ -1124,21 +1124,21 @@ onMounted(() => {
 }
 
 .reset-link:hover {
-  background: var(--filter-action-link-hover-bg);
-  color: var(--filter-action-link-hover-color);
+  background: var(--panel-action-link-hover-bg);
+  color: var(--panel-action-link-hover-color);
   text-decoration: none;
 }
 
 .close-btn {
   background: none;
   border: none;
-  color: var(--filter-close-btn-color);
+  color: var(--panel-close-color);
   cursor: pointer;
-  padding: var(--filter-close-btn-padding);
-  border-radius: var(--filter-close-btn-radius);
-  transition: var(--filter-transition-fast);
-  width: var(--filter-close-btn-size);
-  height: var(--filter-close-btn-size);
+  padding: var(--panel-close-padding);
+  border-radius: var(--panel-close-radius);
+  transition: var(--transition-fast);
+  width: var(--panel-close-size);
+  height: var(--panel-close-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1149,12 +1149,12 @@ onMounted(() => {
 }
 
 .close-btn:hover {
-  background: var(--filter-close-btn-hover-bg);
-  color: var(--filter-close-btn-hover-color);
+  background: var(--panel-close-hover-bg);
+  color: var(--panel-close-hover-color);
 }
 
 .close-btn:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
@@ -1202,7 +1202,7 @@ onMounted(() => {
 }
 
 .price-slider :deep(.el-slider__runway) {
-  background-color: var(--filter-color-neutral-200);
+  background-color: var(--gray-200);
   height: 6px;
 }
 
@@ -1213,7 +1213,7 @@ onMounted(() => {
 
 .price-slider :deep(.el-slider__button) {
   border: 3px solid var(--color-border-strong);
-  background-color: var(--filter-color-bg-primary);
+  background-color: var(--color-bg-primary);
   width: 20px;
   height: 20px;
 }
@@ -1226,26 +1226,26 @@ onMounted(() => {
 .filter-buttons-group {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--filter-space-lg);
+  gap: var(--space-md);
 }
 
 /* 移动端按钮组 */
 @media (width <= 767px) {
   .filter-buttons-group {
-    gap: var(--filter-space-md);
+    gap: var(--space-sm);
   }
 }
 
 .filter-btn {
-  padding: var(--filter-btn-padding-y) var(--filter-btn-padding-x);
-  border: 1px solid var(--filter-color-border-default);
-  border-radius: var(--filter-radius-lg);
-  background: var(--filter-color-bg-primary);
-  font-size: var(--filter-btn-font-size);
-  font-weight: var(--filter-btn-font-weight);
-  color: var(--filter-color-text-primary);
+  padding: var(--button-padding-y) var(--button-padding-x);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-primary);
+  font-size: var(--button-font-size);
+  font-weight: var(--button-font-weight);
+  color: var(--color-text-primary);
   cursor: pointer;
-  transition: var(--filter-transition-normal);
+  transition: var(--transition-normal);
   min-width: 60px;
 
   /* 移动端触摸目标优化 */
@@ -1256,16 +1256,16 @@ onMounted(() => {
 }
 
 .filter-btn:hover {
-  border-color: var(--filter-color-hover-border);
-  color: var(--filter-color-text-primary);
-  background: var(--filter-color-hover-bg);
+  border-color: var(--color-border-hover);
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
 }
 
 .filter-btn.active {
-  background: var(--filter-color-selected-bg);
-  border-color: var(--filter-color-selected-border);
-  color: var(--filter-color-text-primary);
-  font-weight: var(--filter-font-weight-semibold);
+  background: var(--color-selected-bg);
+  border-color: var(--color-selected-border);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 /* 连体分段样式：保留现有颜色/描边/填充，仅处理连体与圆角 */
@@ -1305,8 +1305,8 @@ onMounted(() => {
 /* 移动端按钮优化 */
 @media (width <= 767px) {
   .filter-btn {
-    padding: 14px var(--filter-btn-padding-x);
-    font-size: var(--filter-font-size-md);
+    padding: 14px var(--button-padding-x);
+    font-size: var(--font-size-md);
     min-width: 64px;
     min-height: 48px; /* 更大的触摸目标 */
   }
@@ -1362,7 +1362,7 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   padding: 16px;
-  background: var(--filter-color-bg-muted);
+  background: var(--color-bg-muted);
   border: 1px solid var(--color-border-default);
   border-radius: 8px;
 }
@@ -1400,11 +1400,11 @@ onMounted(() => {
 .cancel-btn:hover {
   border-color: var(--color-border-strong);
   color: var(--color-text-primary);
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .cancel-btn:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
@@ -1412,7 +1412,7 @@ onMounted(() => {
   flex: 2;
   background-color: var(--juwo-primary);
   border-color: var(--juwo-primary);
-  color: var(--filter-btn-primary-color);
+  color: var(--button-primary-color);
   transition: none;
 }
 
@@ -1422,7 +1422,7 @@ onMounted(() => {
 }
 
 .apply-btn:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
@@ -1432,25 +1432,25 @@ onMounted(() => {
 }
 
 .apply-btn:disabled:hover {
-  background-color: var(--filter-btn-primary-bg);
-  border-color: var(--filter-btn-primary-bg);
+  background-color: var(--button-primary-bg);
+  border-color: var(--button-primary-bg);
 }
 
 /* 移动端底部按钮优化 */
 @media (width <= 767px) {
   .panel-footer {
-    padding: var(--filter-space-2xl);
+    padding: var(--space-xl);
 
     /* 为 iOS 底部 Home Bar 预留安全区，确保按钮不被遮挡 */
-    padding-bottom: calc(var(--filter-space-2xl) + env(safe-area-inset-bottom));
-    gap: var(--filter-space-lg);
+    padding-bottom: calc(var(--space-xl) + env(safe-area-inset-bottom));
+    gap: var(--space-md);
   }
 
   .cancel-btn,
   .apply-btn {
     min-height: 52px; /* 移动端更大的触摸目标 */
-    font-size: var(--filter-font-size-lg);
-    font-weight: var(--filter-font-weight-semibold);
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
   }
 }
 
@@ -1459,7 +1459,7 @@ onMounted(() => {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
-  gap: var(--filter-space-md);
+  gap: var(--space-sm);
   /* 新增：白底容器外观 */
   background: var(--color-bg-card);
   border: 1px solid var(--color-border-default);
@@ -1470,25 +1470,25 @@ onMounted(() => {
 .location-chip {
   display: inline-flex;
   align-items: center;
-  gap: var(--filter-chip-gap);
+  gap: var(--chip-gap);
   /* 贴近截图：更紧凑的内边距与更小圆角 */
   padding: 6px 10px;
   border: 1px solid var(--color-border-default);
   border-radius: 4px;
-  background: var(--filter-chip-bg);
-  color: var(--filter-chip-text);
-  font-size: var(--filter-chip-font-size);
-  font-weight: var(--filter-chip-font-weight);
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  font-size: var(--chip-font-size);
+  font-weight: var(--chip-font-weight);
   max-width: 160px;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
 
   /* 移动端触摸优化 */
   min-height: 32px;
 }
 
 .location-chip:hover {
-  border-color: var(--filter-chip-hover-border);
-  background: var(--filter-chip-hover-bg);
+  border-color: var(--chip-hover-border);
+  background: var(--chip-hover-bg);
 }
 
 .location-chip .chip-text {
@@ -1508,12 +1508,12 @@ onMounted(() => {
 }
 
 .location-chip .chip-remove {
-  background: var(--filter-chip-remove-bg);
+  background: var(--chip-remove-bg);
   border: none;
-  color: var(--filter-chip-remove-color);
-  width: var(--filter-chip-remove-size);
-  height: var(--filter-chip-remove-size);
-  border-radius: var(--filter-chip-remove-radius);
+  color: var(--chip-remove-color);
+  width: var(--chip-remove-size);
+  height: var(--chip-remove-size);
+  border-radius: var(--chip-remove-radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1521,7 +1521,7 @@ onMounted(() => {
   line-height: 1;
   padding: 0;
   cursor: pointer;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
   flex-shrink: 0;
 
   /* 移动端触摸目标优化 */
@@ -1530,14 +1530,14 @@ onMounted(() => {
 }
 /* 兼容 BaseChip 子元素命名，保持现有样式生效 */
 .location-chip :deep(.base-chip__remove) {
-  background: var(--filter-chip-remove-bg) !important;
-  background-color: var(--filter-chip-remove-bg) !important;
+  background: var(--chip-remove-bg) !important;
+  background-color: var(--chip-remove-bg) !important;
   background-image: none !important;
   border: none !important;
-  color: var(--filter-chip-remove-color) !important;
-  width: var(--filter-chip-remove-size);
-  height: var(--filter-chip-remove-size);
-  border-radius: var(--filter-chip-remove-radius);
+  color: var(--chip-remove-color) !important;
+  width: var(--chip-remove-size);
+  height: var(--chip-remove-size);
+  border-radius: var(--chip-remove-radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1545,7 +1545,7 @@ onMounted(() => {
   line-height: 1;
   padding: 0;
   cursor: pointer;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
   box-shadow: none !important;
   -webkit-appearance: none;
   appearance: none;
@@ -1558,21 +1558,21 @@ onMounted(() => {
 }
 
 .location-chip .chip-remove:hover {
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 /* 兼容 BaseChip 子元素命名，保持现有样式生效 */
 .location-chip :deep(.base-chip__remove:hover) {
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 
 /* 彻底移除“位置标签 ×”的浅蓝底：选中/hover/focus 均保持中性 remove 背景 */
 .location-chip :deep(.base-chip--selected .base-chip__remove),
 .location-chip :deep(.base-chip__remove:focus),
 .location-chip :deep(.base-chip__remove:focus-visible) {
-  background: var(--filter-chip-remove-bg) !important;
-  color: var(--filter-chip-remove-color) !important;
+  background: var(--chip-remove-bg) !important;
+  color: var(--chip-remove-color) !important;
   outline: none !important;
   box-shadow: none !important;
   border: none !important;
@@ -1582,9 +1582,9 @@ onMounted(() => {
 }
 
 .location-actions {
-  margin-top: var(--filter-space-sm);
+  margin-top: var(--space-xs);
   display: flex;
-  gap: var(--filter-space-lg);
+  gap: var(--space-md);
   align-items: center;
 }
 
@@ -1592,14 +1592,14 @@ onMounted(() => {
 .toggle-chips {
   background: none;
   border: none;
-  color: var(--filter-action-link-color);
+  color: var(--panel-action-link-color);
   text-decoration: underline;
-  font-size: var(--filter-action-link-font-size);
-  font-weight: var(--filter-action-link-font-weight);
+  font-size: var(--panel-action-link-font-size);
+  font-weight: var(--panel-action-link-font-weight);
   cursor: pointer;
-  padding: var(--filter-action-link-padding-y) var(--filter-action-link-padding-x);
-  border-radius: var(--filter-action-link-radius);
-  transition: var(--filter-transition-fast);
+  padding: var(--panel-action-link-padding-y) var(--panel-action-link-padding-x);
+  border-radius: var(--panel-action-link-radius);
+  transition: var(--transition-fast);
 
   /* 移动端触摸目标 */
   min-height: 32px;
@@ -1609,13 +1609,13 @@ onMounted(() => {
 
 .clear-all:hover,
 .toggle-chips:hover {
-  background: var(--filter-action-link-hover-bg);
-  color: var(--filter-action-link-hover-color);
+  background: var(--panel-action-link-hover-bg);
+  color: var(--panel-action-link-hover-color);
   text-decoration: none;
 }
 
 .nearby-toggle {
-  margin-top: var(--filter-space-lg);
+  margin-top: var(--space-md);
 }
 
 /* Location 空态提示 - 使用设计令牌 */
@@ -1623,19 +1623,19 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--filter-space-md);
-  border: 1px solid var(--filter-empty-border);
-  background: var(--filter-empty-bg);
-  border-radius: var(--filter-empty-radius);
-  padding: var(--filter-empty-padding-y) var(--filter-empty-padding-x);
+  gap: var(--space-sm);
+  border: 1px solid var(--panel-empty-border);
+  background: var(--panel-empty-bg);
+  border-radius: var(--panel-empty-radius);
+  padding: var(--panel-empty-padding-y) var(--panel-empty-padding-x);
   text-align: center;
 }
 
 .location-empty .empty-text {
-  font-size: var(--filter-empty-font-size);
-  font-weight: var(--filter-empty-font-weight);
-  color: var(--filter-empty-text-color);
-  line-height: var(--filter-line-height-normal);
+  font-size: var(--panel-empty-font-size);
+  font-weight: var(--panel-empty-font-weight);
+  color: var(--panel-empty-text-color);
+  line-height: var(--line-height-normal);
 }
 
 /* 移动端Location区域优化 */
@@ -1643,28 +1643,28 @@ onMounted(() => {
   .location-section .location-list {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--filter-space-sm);
+    gap: var(--space-xs);
     /* 移动端：更紧凑的内边距与圆角 */
     padding: 8px;
     border-radius: 6px;
   }
 
   .location-chip {
-    padding: calc(var(--filter-chip-padding-y) + 2px) var(--filter-chip-padding-x);
+    padding: calc(var(--chip-padding-y) + 2px) var(--chip-padding-x);
     min-height: 36px;
-    font-size: var(--filter-font-size-md);
+    font-size: var(--font-size-md);
   }
 
   .location-chip .chip-remove {
-    width: calc(var(--filter-chip-remove-size) + 4px);
-    height: calc(var(--filter-chip-remove-size) + 4px);
+    width: calc(var(--chip-remove-size) + 4px);
+    height: calc(var(--chip-remove-size) + 4px);
     min-width: 24px;
     min-height: 24px;
   }
   /* 兼容 BaseChip 子元素命名，保持现有样式生效（移动端尺寸） */
   .location-chip :deep(.base-chip__remove) {
-    width: calc(var(--filter-chip-remove-size) + 4px);
-    height: calc(var(--filter-chip-remove-size) + 4px);
+    width: calc(var(--chip-remove-size) + 4px);
+    height: calc(var(--chip-remove-size) + 4px);
     min-width: 24px;
     min-height: 24px;
   }
@@ -1672,13 +1672,13 @@ onMounted(() => {
   .location-actions {
     flex-direction: column;
     align-items: flex-start;
-    gap: var(--filter-space-sm);
+    gap: var(--space-xs);
   }
 
   .clear-all,
   .toggle-chips {
     min-height: 36px;
-    padding: var(--filter-space-sm) var(--filter-space-md);
+    padding: var(--space-xs) var(--space-sm);
   }
 }
 

--- a/vue-frontend/src/components/FilterTabs.vue
+++ b/vue-frontend/src/components/FilterTabs.vue
@@ -751,7 +751,7 @@ const handleSearchSaved = async (savedSearch) => {
   padding: 0 12px;
   gap: 2px;
   border: 1px solid var(--color-border-default);
-  border-radius: var(--filter-radius-lg);
+  border-radius: var(--radius-sm);
   background: var(--color-bg-card);
   color: var(--color-text-secondary);
   font-weight: 500;
@@ -841,7 +841,7 @@ const handleSearchSaved = async (savedSearch) => {
   padding: 0 12px;
   gap: 6px;
   border: 1px solid var(--juwo-primary);
-  border-radius: var(--filter-radius-lg);
+  border-radius: var(--radius-sm);
   background: var(--juwo-primary);
   color: white;
   font-weight: 600;

--- a/vue-frontend/src/components/MarkdownContent.vue
+++ b/vue-frontend/src/components/MarkdownContent.vue
@@ -154,7 +154,7 @@ const sanitizedHtml = computed(() => {
   margin: 12px 0;
   padding: 8px 16px;
   border-left: 3px solid var(--juwo-primary);
-  background-color: var(--filter-color-bg-secondary);
+  background-color: var(--color-bg-secondary);
   color: var(--color-text-secondary);
 }
 

--- a/vue-frontend/src/components/PropertyCard.vue
+++ b/vue-frontend/src/components/PropertyCard.vue
@@ -184,8 +184,8 @@ const validImages = computed(() => {
 })
 
 const placeholderImage = computed(() => {
-  const background = getCssVarValue('--filter-color-neutral-100', '#f3f4f6')
-  const foreground = getCssVarValue('--filter-color-neutral-400', '#9ca3af')
+  const background = getCssVarValue('--gray-100', '#f3f4f6')
+  const foreground = getCssVarValue('--gray-400', '#9ca3af')
   const placeholderSvg = `<svg width="580" height="386" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="${background}"/><text x="50%" y="50%" font-family="Inter, sans-serif" font-size="18" dy=".3em" fill="${foreground}" text-anchor="middle">${t('propertyCard.imageAlt')}</text></svg>`
   return `data:image/svg+xml,${encodeURIComponent(placeholderSvg)}`
 })

--- a/vue-frontend/src/components/SearchBar.vue
+++ b/vue-frontend/src/components/SearchBar.vue
@@ -638,10 +638,10 @@ watch(
   padding: 6px 10px;
   border: 1px solid var(--color-border-default);
   border-radius: 4px;
-  background: var(--filter-chip-bg);
-  color: var(--filter-chip-text, var(--color-text-secondary));
-  font-size: var(--filter-chip-font-size);
-  font-weight: var(--filter-chip-font-weight);
+  background: var(--chip-bg);
+  color: var(--chip-text, var(--color-text-secondary));
+  font-size: var(--chip-font-size);
+  font-weight: var(--chip-font-weight);
   line-height: 1;
   min-height: 32px; /* 与面板回显 chip 触控/对齐一致 */
 }
@@ -658,16 +658,16 @@ watch(
 }
 
 .inline-chip-more {
-  color: var(--filter-chip-text, var(--color-text-secondary));
-  background: var(--filter-chip-bg);
+  color: var(--chip-text, var(--color-text-secondary));
+  background: var(--chip-bg);
   border: 1px solid var(--color-border-default);
   border-radius: 4px;
 }
 /* Hover 态轻微加深，保持中性风格（与面板一致） */
 .inline-chip:hover,
 .inline-chip-more:hover {
-  background: var(--filter-chip-hover-bg);
-  border-color: var(--filter-chip-hover-border);
+  background: var(--chip-hover-bg);
+  border-color: var(--chip-hover-border);
   color: var(--color-text-primary);
 }
 
@@ -676,8 +676,8 @@ watch(
   pointer-events: auto;
   margin-left: 6px;
   border: none;
-  background: var(--filter-chip-remove-bg);
-  color: var(--filter-chip-remove-color);
+  background: var(--chip-remove-bg);
+  color: var(--chip-remove-color);
   cursor: pointer;
   font-size: 12px;
   line-height: 1;
@@ -685,14 +685,14 @@ watch(
   display: inline-flex;          /* 与文本中线对齐 */
   align-items: center;           /* 垂直居中 */
   justify-content: center;
-  width: var(--filter-chip-remove-size);
-  height: var(--filter-chip-remove-size);
-  border-radius: var(--filter-chip-remove-radius);
+  width: var(--chip-remove-size);
+  height: var(--chip-remove-size);
+  border-radius: var(--chip-remove-radius);
 }
 
 .inline-chip-remove:hover {
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 
 /* 规范化焦点：移除浏览器默认浅蓝高亮（仅几何/可达性，不改配色语义） */
@@ -700,8 +700,8 @@ watch(
 .inline-chip-remove:focus-visible {
   outline: none;
   box-shadow: none;
-  background: var(--filter-chip-remove-bg);
-  color: var(--filter-chip-remove-color);
+  background: var(--chip-remove-bg);
+  color: var(--chip-remove-color);
 }
 
 /* 统一原生外观与点击高亮 */
@@ -712,8 +712,8 @@ watch(
 }
 
 .inline-chip-remove:active {
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 
 .suggestion-item {

--- a/vue-frontend/src/components/SearchOverlay.vue
+++ b/vue-frontend/src/components/SearchOverlay.vue
@@ -355,7 +355,7 @@ watch(
   position: fixed;
   inset: 0;
   z-index: 10050;
-  background: var(--filter-panel-bg, var(--filter-color-bg-primary));
+  background: var(--panel-bg, var(--color-bg-primary));
   display: flex;
   flex-direction: column;
   height: 100dvh; /* 可见视口高度，适配 iOS */
@@ -371,8 +371,8 @@ watch(
   align-items: center;
   gap: 8px;
   padding: 12px 12px calc(12px + env(safe-area-inset-top, 0px));
-  border-bottom: 1px solid var(--filter-color-border-default);
-  background: var(--filter-color-bg-primary);
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-primary);
   z-index: 1;
 }
 
@@ -389,7 +389,7 @@ watch(
 }
 
 .icon-btn:active {
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .spec-icon {
@@ -403,8 +403,8 @@ watch(
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--filter-color-bg-primary);
-  border: 1px solid var(--filter-color-border-default);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-default);
   border-radius: 8px;
   padding: 0 8px;
 }
@@ -427,7 +427,7 @@ watch(
 }
 
 .filter-text-btn:active {
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .search-prefix {
@@ -449,11 +449,11 @@ watch(
 /* 已选 chips */
 .chips-row {
   display: flex;
-  gap: var(--filter-chip-gap);
-  padding: var(--filter-space-md) var(--filter-space-lg);
+  gap: var(--chip-gap);
+  padding: var(--space-sm) var(--space-md);
   overflow-x: auto;
-  border-bottom: 1px solid var(--filter-color-border-default);
-  background: var(--filter-color-bg-primary);
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-primary);
 }
 
 /* 活动 chip 的"输入光标"效果 */
@@ -488,9 +488,9 @@ watch(
   padding: 12px;
   font-size: 11px;
   font-weight: 600;
-  color: var(--filter-color-text-secondary);
-  background: var(--filter-group-title-bg);
-  border-bottom: 1px solid var(--filter-group-title-border);
+  color: var(--color-text-secondary);
+  background: var(--panel-group-bg);
+  border-bottom: 1px solid var(--panel-group-border);
   letter-spacing: 0.5px;
   text-transform: uppercase;
 }
@@ -498,7 +498,7 @@ watch(
 .title-icon {
   width: 14px;
   height: 14px;
-  color: var(--filter-color-text-muted);
+  color: var(--color-text-muted);
 }
 
 .pill {
@@ -507,16 +507,16 @@ watch(
   justify-content: center;
   width: 28px;
   height: 28px;
-  border: 1px solid var(--filter-color-border-default);
+  border: 1px solid var(--color-border-default);
   border-radius: 999px;
-  background: var(--filter-color-bg-primary);
-  color: var(--filter-color-text-secondary);
+  background: var(--color-bg-primary);
+  color: var(--color-text-secondary);
 }
 
 .pill.selected {
   background: var(--juwo-primary);
   border-color: var(--juwo-primary);
-  color: var(--filter-btn-primary-color);
+  color: var(--button-primary-color);
 }
 
 .pill-icon {
@@ -538,7 +538,7 @@ watch(
 .spinner {
   width: 16px;
   height: 16px;
-  border: 2px solid var(--filter-color-border-subtle);
+  border: 2px solid var(--color-border-subtle);
   border-top-color: var(--juwo-primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
@@ -558,43 +558,43 @@ watch(
 /* 设计令牌对齐覆盖（追加覆盖而非重写原样式，降低风险）
    为什么这样做：
    - 移动端搜索覆盖层需要与筛选面板共用一套设计语言（中性灰、统一间距/圆角/边框）
-   - 通过后置覆盖使用 design-tokens.css 中的 --filter-* 变量，避免大规模重写，保持向后兼容
+   - 通过后置覆盖使用 design-tokens.css 中的语义令牌（--color-*/--space-*/--panel-*），避免大规模重写
    - 若 design tokens 未来微调，可全局生效；此处仅做映射与对齐 */
 :root {
 }
 
 .search-overlay {
-  background: var(--filter-panel-bg, var(--filter-color-bg-primary));
+  background: var(--panel-bg, var(--color-bg-primary));
 }
 
 /* 头部与输入区 */
 .overlay-header {
-  gap: var(--filter-space-md);
-  padding: var(--filter-space-lg) var(--filter-space-lg)
-    calc(var(--filter-space-lg) + env(safe-area-inset-top, 0px));
-  border-bottom: 1px solid var(--filter-color-border-default);
-  background: var(--filter-color-bg-primary);
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-md)
+    calc(var(--space-md) + env(safe-area-inset-top, 0px));
+  border-bottom: 1px solid var(--color-border-default);
+  background: var(--color-bg-primary);
 }
 
 .icon-btn {
-  color: var(--filter-color-text-secondary);
-  border-radius: var(--filter-radius-lg);
+  color: var(--color-text-secondary);
+  border-radius: var(--radius-sm);
 }
 
 .icon-btn:active {
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .header-input {
-  background: var(--filter-color-bg-primary);
-  border: 1px solid var(--filter-color-border-default);
-  border-radius: var(--filter-radius-xl);
-  padding: 0 var(--filter-space-md);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  padding: 0 var(--space-sm);
 }
 
 .header-actions {
-  margin-left: var(--filter-space-md);
-  gap: var(--filter-space-md);
+  margin-left: var(--space-sm);
+  gap: var(--space-sm);
 }
 
 .filter-text-btn {
@@ -602,50 +602,50 @@ watch(
 }
 
 .filter-text-btn:active {
-  background: var(--filter-color-hover-bg);
+  background: var(--color-surface-hover);
 }
 
 .search-prefix {
-  color: var(--filter-color-text-secondary);
+  color: var(--color-text-secondary);
 }
 
 .input {
-  color: var(--filter-color-text-primary);
+  color: var(--color-text-primary);
 }
 
 /* 内容区与分组标题 */
 .overlay-content {
-  padding-bottom: calc(var(--filter-space-lg) + env(safe-area-inset-bottom, 0px));
+  padding-bottom: calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
 }
 
 .section-title {
-  padding: var(--filter-group-title-padding-y) var(--filter-group-title-padding-x);
-  font-size: var(--filter-group-title-font-size);
-  font-weight: var(--filter-group-title-font-weight);
-  color: var(--filter-group-title-color);
-  background: var(--filter-group-title-bg);
-  border-bottom: 1px solid var(--filter-group-title-border);
+  padding: var(--panel-group-padding-y) var(--panel-group-padding-x);
+  font-size: var(--panel-group-font-size);
+  font-weight: var(--panel-group-font-weight);
+  color: var(--panel-group-color);
+  background: var(--panel-group-bg);
+  border-bottom: 1px solid var(--panel-group-border);
 }
 
 .title-icon {
-  color: var(--filter-color-text-muted);
+  color: var(--color-text-muted);
 }
 
 /* 操作徽标与空/加载态 */
 .pill {
-  border: 1px solid var(--filter-color-border-default);
-  color: var(--filter-color-text-secondary);
+  border: 1px solid var(--color-border-default);
+  color: var(--color-text-secondary);
 }
 
 .loading,
 .empty {
-  padding: var(--filter-space-xl);
-  font-size: var(--filter-font-size-sm);
-  color: var(--filter-color-text-secondary);
+  padding: var(--space-lg);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .spinner {
-  border: 2px solid var(--filter-color-border-subtle);
+  border: 2px solid var(--color-border-subtle);
   border-top-color: var(--juwo-primary);
 }
 </style>

--- a/vue-frontend/src/components/base/BaseButton.vue
+++ b/vue-frontend/src/components/base/BaseButton.vue
@@ -114,15 +114,15 @@ const handleClick = (event) => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--filter-btn-gap);
-  padding: var(--filter-btn-padding-y) var(--filter-btn-padding-x);
-  font-size: var(--filter-btn-font-size);
-  font-weight: var(--filter-btn-font-weight);
-  line-height: var(--filter-line-height-normal);
-  border-radius: var(--filter-btn-radius);
+  gap: var(--button-gap);
+  padding: var(--button-padding-y) var(--button-padding-x);
+  font-size: var(--button-font-size);
+  font-weight: var(--button-font-weight);
+  line-height: var(--line-height-normal);
+  border-radius: var(--button-radius);
   border: 1px solid transparent;
   cursor: pointer;
-  transition: var(--filter-transition-normal);
+  transition: var(--transition-normal);
   text-decoration: none;
   white-space: nowrap;
   user-select: none;
@@ -152,14 +152,14 @@ const handleClick = (event) => {
 
 /* 主要按钮 */
 .base-button--primary {
-  background: var(--filter-btn-primary-bg);
-  color: var(--filter-btn-primary-color);
-  border-color: var(--filter-btn-primary-bg);
+  background: var(--button-primary-bg);
+  color: var(--button-primary-color);
+  border-color: var(--button-primary-bg);
 }
 
 .base-button--primary:hover:not(:disabled) {
-  background: var(--filter-btn-primary-hover-bg);
-  border-color: var(--filter-btn-primary-hover-bg);
+  background: var(--button-primary-hover-bg);
+  border-color: var(--button-primary-hover-bg);
 }
 
 .base-button--primary:active:not(:disabled) {
@@ -168,15 +168,15 @@ const handleClick = (event) => {
 
 /* 次要按钮 */
 .base-button--secondary {
-  background: var(--filter-btn-secondary-bg);
-  color: var(--filter-btn-secondary-color);
-  border-color: var(--filter-btn-secondary-border);
+  background: var(--button-secondary-bg);
+  color: var(--button-secondary-color);
+  border-color: var(--button-secondary-border);
 }
 
 .base-button--secondary:hover:not(:disabled) {
-  border-color: var(--filter-btn-secondary-hover-border);
-  color: var(--filter-btn-secondary-hover-color);
-  background: var(--filter-color-hover-bg);
+  border-color: var(--button-secondary-hover-border);
+  color: var(--button-secondary-hover-color);
+  background: var(--color-surface-hover);
 }
 
 .base-button--secondary:active:not(:disabled) {
@@ -186,33 +186,33 @@ const handleClick = (event) => {
 /* 幽灵按钮 */
 .base-button--ghost {
   background: transparent;
-  color: var(--filter-color-text-secondary);
+  color: var(--color-text-secondary);
   border-color: transparent;
 }
 
 .base-button--ghost:hover:not(:disabled) {
-  background: var(--filter-color-hover-bg);
-  color: var(--filter-color-text-primary);
+  background: var(--color-surface-hover);
+  color: var(--color-text-primary);
 }
 
 /* 危险按钮 */
 .base-button--danger {
-  background: var(--filter-color-danger);
-  color: var(--filter-btn-primary-color);
-  border-color: var(--filter-color-danger);
+  background: var(--color-danger);
+  color: var(--button-primary-color);
+  border-color: var(--color-danger);
 }
 
 .base-button--danger:hover:not(:disabled) {
-  background: var(--filter-color-danger-hover);
-  border-color: var(--filter-color-danger-hover);
+  background: var(--color-danger-hover);
+  border-color: var(--color-danger-hover);
 }
 
 /* 按钮尺寸 */
 
 .base-button--small {
-  padding: var(--filter-space-sm) var(--filter-space-lg);
-  font-size: var(--filter-font-size-sm);
-  gap: var(--filter-space-sm);
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--font-size-sm);
+  gap: var(--space-xs);
 }
 
 .base-button--small .base-button__loading-icon {
@@ -225,9 +225,9 @@ const handleClick = (event) => {
 }
 
 .base-button--large {
-  padding: var(--filter-space-xl) var(--filter-space-2xl);
-  font-size: var(--filter-font-size-lg);
-  gap: var(--filter-space-lg);
+  padding: var(--space-lg) var(--space-xl);
+  font-size: var(--font-size-lg);
+  gap: var(--space-md);
 }
 
 .base-button--large .base-button__loading-icon {
@@ -259,7 +259,7 @@ const handleClick = (event) => {
 
 /* 焦点样式 */
 .base-button:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
@@ -277,28 +277,28 @@ const handleClick = (event) => {
 /* 响应式调整 */
 @media (width <= 767px) {
   .base-button {
-    padding: calc(var(--filter-btn-padding-y) + 2px) var(--filter-btn-padding-x);
-    font-size: var(--filter-font-size-md);
+    padding: calc(var(--button-padding-y) + 2px) var(--button-padding-x);
+    font-size: var(--font-size-md);
   }
 
   .base-button--small {
-    padding: var(--filter-space-md) var(--filter-space-lg);
+    padding: var(--space-sm) var(--space-md);
   }
 
   .base-button--large {
-    padding: calc(var(--filter-space-xl) + 2px) var(--filter-space-2xl);
+    padding: calc(var(--space-lg) + 2px) var(--space-xl);
   }
 }
 
 /* 按钮组合样式（当多个按钮相邻时） */
 .base-button + .base-button {
-  margin-left: var(--filter-space-lg);
+  margin-left: var(--space-md);
 }
 
 /* 在 flex 容器中的按钮间距 */
 .base-button-group {
   display: flex;
-  gap: var(--filter-space-lg);
+  gap: var(--space-md);
   align-items: center;
 }
 

--- a/vue-frontend/src/components/base/BaseChip.vue
+++ b/vue-frontend/src/components/base/BaseChip.vue
@@ -62,17 +62,17 @@ const handleRemove = (event) => {
   /* 使用设计令牌 */
   display: inline-flex;
   align-items: center;
-  gap: var(--filter-chip-gap);
-  padding: var(--filter-chip-padding-y) var(--filter-chip-padding-x);
-  border: 1px solid var(--filter-chip-border);
-  border-radius: var(--filter-chip-radius);
-  background: var(--filter-chip-bg);
-  color: var(--filter-chip-text);
-  font-size: var(--filter-chip-font-size);
-  font-weight: var(--filter-chip-font-weight);
-  line-height: var(--filter-line-height-normal);
+  gap: var(--chip-gap);
+  padding: var(--chip-padding-y) var(--chip-padding-x);
+  border: 1px solid var(--chip-border);
+  border-radius: var(--chip-radius);
+  background: var(--chip-bg);
+  color: var(--chip-text);
+  font-size: var(--chip-font-size);
+  font-weight: var(--chip-font-weight);
+  line-height: var(--line-height-normal);
   max-width: 200px;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
   cursor: default;
 }
 
@@ -85,12 +85,12 @@ const handleRemove = (event) => {
 
 .base-chip__remove {
   /* 使用中性 remove 背景，避免父级选中/hover 背景透出 */
-  background: var(--filter-chip-remove-bg);
+  background: var(--chip-remove-bg);
   border: none;
-  color: var(--filter-chip-remove-color);
-  width: var(--filter-chip-remove-size);
-  height: var(--filter-chip-remove-size);
-  border-radius: var(--filter-chip-remove-radius);
+  color: var(--chip-remove-color);
+  width: var(--chip-remove-size);
+  height: var(--chip-remove-size);
+  border-radius: var(--chip-remove-radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -98,26 +98,26 @@ const handleRemove = (event) => {
   line-height: 1;
   padding: 0;
   cursor: pointer;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
   flex-shrink: 0;
 }
 
 /* 悬浮状态 */
 .base-chip:hover {
-  border-color: var(--filter-chip-hover-border);
-  background: var(--filter-chip-hover-bg);
+  border-color: var(--chip-hover-border);
+  background: var(--chip-hover-bg);
 }
 
 .base-chip__remove:hover {
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 
 /* 选中/hover 场景下，仍保持 x 的中性背景，避免父级底色透出 */
 .base-chip:hover .base-chip__remove,
 .base-chip--selected .base-chip__remove,
 .base-chip.base-chip--hover .base-chip__remove {
-  background: var(--filter-chip-remove-bg) !important;
+  background: var(--chip-remove-bg) !important;
 }
 
 /* 规范化原生外观与点击高亮（消除桌面端浅蓝背景） */
@@ -129,26 +129,26 @@ const handleRemove = (event) => {
 
 .base-chip__remove:active {
   /* 点击时使用 hover-bg，非选中/焦点时保持透明 */
-  background: var(--filter-chip-remove-hover-bg);
-  color: var(--filter-chip-remove-hover-color);
+  background: var(--chip-remove-hover-bg);
+  color: var(--chip-remove-hover-color);
 }
 
 /* 变体样式 */
 .base-chip--selected {
-  background: var(--filter-color-selected-bg);
-  border-color: var(--filter-color-selected-border);
-  color: var(--filter-color-text-primary);
-  font-weight: var(--filter-font-weight-semibold);
+  background: var(--color-selected-bg);
+  border-color: var(--color-selected-border);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .base-chip--hover {
-  background: var(--filter-chip-hover-bg);
-  border-color: var(--filter-chip-hover-border);
+  background: var(--chip-hover-bg);
+  border-color: var(--chip-hover-border);
 }
 
 /* 可移除状态的额外样式 */
 .base-chip--removable {
-  padding-right: calc(var(--filter-chip-padding-x) - 2px); /* 为移除按钮调整内边距 */
+  padding-right: calc(var(--chip-padding-x) - 2px); /* 为移除按钮调整内边距 */
 }
 
 /* 无障碍支持（中性化：移除浏览器默认浅蓝高亮） */
@@ -157,8 +157,8 @@ const handleRemove = (event) => {
   outline: none !important;
   box-shadow: none !important;
   /* 焦点保持中性 remove 背景，避免父级选中底色透出 */
-  background: var(--filter-chip-remove-bg) !important;
-  color: var(--filter-chip-remove-color) !important;
+  background: var(--chip-remove-bg) !important;
+  color: var(--chip-remove-color) !important;
 }
 
 /* Firefox 内边距/边框清理，避免焦点内边线 */
@@ -170,13 +170,13 @@ const handleRemove = (event) => {
 /* 响应式调整 */
 @media (width <= 767px) {
   .base-chip {
-    font-size: var(--filter-font-size-md); /* 移动端稍大字体 */
-    padding: calc(var(--filter-chip-padding-y) + 1px) var(--filter-chip-padding-x);
+    font-size: var(--font-size-md); /* 移动端稍大字体 */
+    padding: calc(var(--chip-padding-y) + 1px) var(--chip-padding-x);
   }
 
   .base-chip__remove {
-    width: calc(var(--filter-chip-remove-size) + 2px);
-    height: calc(var(--filter-chip-remove-size) + 2px);
+    width: calc(var(--chip-remove-size) + 2px);
+    height: calc(var(--chip-remove-size) + 2px);
   }
 }
 </style>

--- a/vue-frontend/src/components/base/BaseListItem.vue
+++ b/vue-frontend/src/components/base/BaseListItem.vue
@@ -123,18 +123,18 @@ const handleKeydown = (event) => {
   /* 使用设计令牌 */
   display: flex;
   align-items: center;
-  padding: var(--filter-list-item-padding-y) var(--filter-list-item-padding-x);
-  min-height: var(--filter-list-item-min-height);
-  background: var(--filter-color-bg-primary);
-  color: var(--filter-color-text-primary);
-  transition: var(--filter-transition-fast);
+  padding: var(--list-item-padding-y) var(--list-item-padding-x);
+  min-height: var(--list-item-min-height);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  transition: var(--transition-fast);
   position: relative;
 }
 
 .base-list-item__prefix {
   display: flex;
   align-items: center;
-  margin-right: var(--filter-space-lg);
+  margin-right: var(--space-md);
   flex-shrink: 0;
 }
 
@@ -144,10 +144,10 @@ const handleKeydown = (event) => {
 }
 
 .base-list-item__title {
-  font-size: var(--filter-font-size-md);
-  font-weight: var(--filter-font-weight-normal);
-  line-height: var(--filter-line-height-normal);
-  color: var(--filter-color-text-primary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-primary);
 
   /* 文本截断 */
   overflow: hidden;
@@ -156,11 +156,11 @@ const handleKeydown = (event) => {
 }
 
 .base-list-item__description {
-  font-size: var(--filter-font-size-sm);
-  font-weight: var(--filter-font-weight-normal);
-  line-height: var(--filter-line-height-normal);
-  color: var(--filter-color-text-secondary);
-  margin-top: var(--filter-space-xs);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-secondary);
+  margin-top: var(--space-2xs);
 
   /* 文本截断 */
   overflow: hidden;
@@ -171,13 +171,13 @@ const handleKeydown = (event) => {
 .base-list-item__suffix {
   display: flex;
   align-items: center;
-  margin-left: var(--filter-space-lg);
+  margin-left: var(--space-md);
   flex-shrink: 0;
 }
 
 /* 边框样式 */
 .base-list-item--bordered {
-  border-bottom: 1px solid var(--filter-list-item-border);
+  border-bottom: 1px solid var(--list-item-border);
 }
 
 .base-list-item--bordered:last-child {
@@ -190,22 +190,22 @@ const handleKeydown = (event) => {
 }
 
 .base-list-item--clickable:hover:not(.base-list-item--disabled) {
-  background: var(--filter-list-item-hover-bg);
+  background: var(--list-item-hover-bg);
 }
 
 .base-list-item--clickable:active:not(.base-list-item--disabled) {
-  background: var(--filter-color-bg-muted);
+  background: var(--color-bg-muted);
 }
 
 /* 选中状态 */
 .base-list-item--selected {
-  background: var(--filter-list-item-selected-bg);
-  border-color: var(--filter-list-item-selected-border);
+  background: var(--list-item-selected-bg);
+  border-color: var(--list-item-selected-border);
 }
 
 .base-list-item--selected .base-list-item__title {
-  color: var(--filter-color-text-primary);
-  font-weight: var(--filter-font-weight-semibold);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 /* 禁用状态 */
@@ -217,18 +217,18 @@ const handleKeydown = (event) => {
 
 /* 焦点样式 */
 .base-list-item--clickable:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: -2px;
 }
 
 /* 分组标题样式（特殊变体） */
 .base-list-item--group-title {
-  background: var(--filter-group-title-bg);
-  padding: var(--filter-group-title-padding-y) var(--filter-group-title-padding-x);
-  font-size: var(--filter-group-title-font-size);
-  font-weight: var(--filter-group-title-font-weight);
-  color: var(--filter-group-title-color);
-  border-bottom: 1px solid var(--filter-group-title-border);
+  background: var(--panel-group-bg);
+  padding: var(--panel-group-padding-y) var(--panel-group-padding-x);
+  font-size: var(--panel-group-font-size);
+  font-weight: var(--panel-group-font-weight);
+  color: var(--panel-group-color);
+  border-bottom: 1px solid var(--panel-group-border);
   position: sticky;
   top: 0;
   z-index: 2;
@@ -246,24 +246,24 @@ const handleKeydown = (event) => {
 /* 响应式调整 */
 @media (width <= 767px) {
   .base-list-item {
-    padding: calc(var(--filter-list-item-padding-y) + 2px) var(--filter-list-item-padding-x);
-    min-height: calc(var(--filter-list-item-min-height) + 4px);
+    padding: calc(var(--list-item-padding-y) + 2px) var(--list-item-padding-x);
+    min-height: calc(var(--list-item-min-height) + 4px);
   }
 
   .base-list-item__title {
-    font-size: var(--filter-font-size-md);
+    font-size: var(--font-size-md);
   }
 
   .base-list-item__description {
-    font-size: var(--filter-font-size-sm);
+    font-size: var(--font-size-sm);
   }
 
   .base-list-item__prefix {
-    margin-right: var(--filter-space-md);
+    margin-right: var(--space-sm);
   }
 
   .base-list-item__suffix {
-    margin-left: var(--filter-space-md);
+    margin-left: var(--space-sm);
   }
 }
 
@@ -296,17 +296,17 @@ const handleKeydown = (event) => {
 
 /* 紧凑模式 */
 .base-list-item--compact {
-  padding: var(--filter-space-sm) var(--filter-list-item-padding-x);
+  padding: var(--space-xs) var(--list-item-padding-x);
   min-height: auto;
 }
 
 .base-list-item--compact .base-list-item__title {
-  font-size: var(--filter-font-size-sm);
+  font-size: var(--font-size-sm);
 }
 
 .base-list-item--compact .base-list-item__description {
-  font-size: var(--filter-font-size-xs);
-  margin-top: var(--filter-space-xs);
+  font-size: var(--font-size-2xs);
+  margin-top: var(--space-2xs);
 }
 
 /* 多行文本支持 */

--- a/vue-frontend/src/components/base/BaseSearchInput.vue
+++ b/vue-frontend/src/components/base/BaseSearchInput.vue
@@ -201,84 +201,84 @@ defineExpose({
 
 .base-search-input__icon {
   position: absolute;
-  left: var(--filter-search-icon-left);
-  width: var(--filter-search-icon-size);
-  height: var(--filter-search-icon-size);
-  color: var(--filter-search-icon-color);
+  left: var(--search-icon-left);
+  width: var(--search-icon-size);
+  height: var(--search-icon-size);
+  color: var(--search-icon-color);
   pointer-events: none;
   z-index: 1;
 }
 
 .base-search-input__field {
   width: 100%;
-  padding: var(--filter-search-padding-y) var(--filter-search-padding-x)
-    var(--filter-search-padding-y) var(--filter-search-padding-left);
-  font-size: var(--filter-search-font-size);
-  color: var(--filter-color-text-primary);
-  background: var(--filter-color-bg-primary);
-  border: 1px solid var(--filter-search-border);
-  border-radius: var(--filter-search-radius);
+  padding: var(--search-padding-y) var(--search-padding-x)
+    var(--search-padding-y) var(--search-padding-left);
+  font-size: var(--search-font-size);
+  color: var(--color-text-primary);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--search-border);
+  border-radius: var(--search-radius);
   outline: none;
-  transition: var(--filter-transition-normal);
-  line-height: var(--filter-line-height-normal);
+  transition: var(--transition-normal);
+  line-height: var(--line-height-normal);
 }
 
 .base-search-input__field::placeholder {
-  color: var(--filter-color-text-muted);
+  color: var(--color-text-muted);
 }
 
 .base-search-input__field:focus {
-  border-color: var(--filter-search-focus-border);
-  box-shadow: var(--filter-shadow-focus);
+  border-color: var(--search-focus-border);
+  box-shadow: var(--shadow-focus);
 }
 
 .base-search-input__field:hover:not(:focus, :disabled) {
-  border-color: var(--filter-search-hover-border);
+  border-color: var(--search-hover-border);
 }
 
 .base-search-input__field:disabled {
-  background: var(--filter-color-bg-muted);
-  color: var(--filter-color-text-muted);
+  background: var(--color-bg-muted);
+  color: var(--color-text-muted);
   cursor: not-allowed;
 }
 
 .base-search-input__clear {
   position: absolute;
-  right: var(--filter-clear-btn-right);
+  right: var(--clear-btn-right);
   background: none;
   border: none;
-  color: var(--filter-color-text-secondary);
+  color: var(--color-text-secondary);
   cursor: pointer;
-  padding: var(--filter-clear-btn-padding);
-  border-radius: var(--filter-clear-btn-radius);
+  padding: var(--clear-btn-padding);
+  border-radius: var(--clear-btn-radius);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: var(--filter-transition-fast);
-  width: var(--filter-clear-btn-size);
-  height: var(--filter-clear-btn-size);
+  transition: var(--transition-fast);
+  width: var(--clear-btn-size);
+  height: var(--clear-btn-size);
 }
 
 .base-search-input__clear svg {
-  width: var(--filter-clear-btn-size);
-  height: var(--filter-clear-btn-size);
+  width: var(--clear-btn-size);
+  height: var(--clear-btn-size);
 }
 
 .base-search-input__clear:hover {
-  background: var(--filter-clear-btn-hover-bg);
-  color: var(--filter-color-text-primary);
+  background: var(--clear-btn-hover-bg);
+  color: var(--color-text-primary);
 }
 
 .base-search-input__clear:focus-visible {
-  outline: 2px solid var(--filter-color-focus-ring);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
 }
 
 /* 有清除按钮时调整输入框右内边距 */
 .base-search-input__field:not(:disabled) {
   padding-right: calc(
-    var(--filter-clear-btn-right) * 2 + var(--filter-clear-btn-size) +
-      var(--filter-clear-btn-padding) * 2
+    var(--clear-btn-right) * 2 + var(--clear-btn-size) +
+      var(--clear-btn-padding) * 2
   );
 }
 
@@ -286,14 +286,14 @@ defineExpose({
 @media (width <= 767px) {
   .base-search-input__field {
     font-size: 16px; /* iOS 防缩放 */
-    padding: calc(var(--filter-search-padding-y) + 2px) var(--filter-search-padding-x)
-      calc(var(--filter-search-padding-y) + 2px) var(--filter-search-padding-left);
+    padding: calc(var(--search-padding-y) + 2px) var(--search-padding-x)
+      calc(var(--search-padding-y) + 2px) var(--search-padding-left);
   }
 
   .base-search-input__clear {
-    width: calc(var(--filter-clear-btn-size) + 4px);
-    height: calc(var(--filter-clear-btn-size) + 4px);
-    padding: calc(var(--filter-clear-btn-padding) + 2px);
+    width: calc(var(--clear-btn-size) + 4px);
+    height: calc(var(--clear-btn-size) + 4px);
+    padding: calc(var(--clear-btn-padding) + 2px);
   }
 }
 

--- a/vue-frontend/src/components/base/README.md
+++ b/vue-frontend/src/components/base/README.md
@@ -17,32 +17,32 @@
 
 ### 颜色系统
 
-- **中性灰色调**：`--filter-color-neutral-50` 到 `--filter-color-neutral-900`
-- **语义化颜色**：`--filter-color-bg-primary`、`--filter-color-text-primary` 等
-- **交互状态颜色**：`--filter-color-hover-bg`、`--filter-color-focus-ring` 等
+- **中性灰色调**：`--gray-50` 到 `--gray-900`
+- **语义化颜色**：`--color-bg-primary`、`--color-text-primary` 等
+- **交互状态颜色**：`--color-surface-hover`、`--color-focus-ring` 等
 
 ### 间距系统
 
-- `--filter-space-xs`: 4px
-- `--filter-space-sm`: 6px
-- `--filter-space-md`: 8px
-- `--filter-space-lg`: 12px
-- `--filter-space-xl`: 16px
-- `--filter-space-2xl`: 20px
-- `--filter-space-3xl`: 24px
+- `--space-2xs`: 4px
+- `--space-xs`: 6px
+- `--space-sm`: 8px
+- `--space-md`: 12px
+- `--space-lg`: 16px
+- `--space-xl`: 20px
+- `--space-2xl`: 24px
 
 ### 字体系统
 
-- **字号**：`--filter-font-size-xs` (11px) 到 `--filter-font-size-xl` (18px)
-- **字重**：`--filter-font-weight-normal` (400) 到 `--filter-font-weight-bold` (700)
-- **行高**：`--filter-line-height-tight` (1.2) 到 `--filter-line-height-relaxed` (1.6)
+- **字号**：`--font-size-2xs` (11px) 到 `--font-size-xl` (18px)
+- **字重**：`--font-weight-regular` (400) 到 `--font-weight-bold` (700)
+- **行高**：`--line-height-tight` (1.2) 到 `--line-height-relaxed` (1.6)
 
 ### 圆角系统
 
-- `--filter-radius-sm`: 2px
-- `--filter-radius-md`: 4px
-- `--filter-radius-lg`: 6px
-- `--filter-radius-xl`: 8px
+- `--radius-2xs`: 2px
+- `--radius-xs`: 4px
+- `--radius-sm`: 6px
+- `--radius-md`: 8px
 
 ## 基础组件
 
@@ -179,28 +179,24 @@ import BaseListItem from '@/components/base/BaseListItem.vue'
 
 ```css
 .my-component {
-  padding: var(--filter-space-lg);
-  background: var(--filter-color-bg-primary);
-  border: 1px solid var(--filter-color-border-default);
-  border-radius: var(--filter-radius-md);
-  color: var(--filter-color-text-primary);
-  font-size: var(--filter-font-size-md);
-  transition: var(--filter-transition-normal);
+  padding: var(--space-md);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  transition: var(--transition-normal);
 }
 
 .my-component:hover {
-  background: var(--filter-color-hover-bg);
-  border-color: var(--filter-color-hover-border);
+  background: var(--color-surface-hover);
+  border-color: var(--color-border-hover);
 }
 ```
 
 ### 3. 工具类
 
-可以使用预定义的工具类：
-
-```html
-<div class="filter-text-primary filter-bg-secondary filter-radius-md">使用工具类的内容</div>
-```
+可以直接通过 CSS 变量或项目内的 `.typo-*`、`.page__*` 等工具类组合样式。
 
 ### 4. 响应式设计
 
@@ -214,35 +210,35 @@ import BaseListItem from '@/components/base/BaseListItem.vue'
 
 ### 1. 颜色使用
 
-- **主要文本**：使用 `--filter-color-text-primary`
-- **次要文本**：使用 `--filter-color-text-secondary`
-- **边框**：使用 `--filter-color-border-default`
-- **背景**：使用 `--filter-color-bg-primary` 或 `--filter-color-bg-secondary`
+- **主要文本**：使用 `--color-text-primary`
+- **次要文本**：使用 `--color-text-secondary`
+- **边框**：使用 `--color-border-default`
+- **背景**：使用 `--color-bg-primary` 或 `--color-bg-secondary`
 
 ### 2. 间距使用
 
-- **组件内部间距**：使用 `--filter-space-md` (8px)
-- **组件之间间距**：使用 `--filter-space-lg` (12px) 或 `--filter-space-xl` (16px)
-- **区块间距**：使用 `--filter-space-2xl` (20px) 或 `--filter-space-3xl` (24px)
+- **组件内部间距**：使用 `--space-sm` (8px)
+- **组件之间间距**：使用 `--space-md` (12px) 或 `--space-lg` (16px)
+- **区块间距**：使用 `--space-xl` (20px) 或 `--space-2xl` (24px)
 
 ### 3. 交互状态
 
-- **悬浮状态**：使用 `--filter-color-hover-bg` 和 `--filter-color-hover-border`
-- **选中状态**：使用 `--filter-color-selected-bg` 和 `--filter-color-selected-border`
-- **焦点状态**：使用 `--filter-color-focus-ring`
+- **悬浮状态**：使用 `--color-surface-hover` 和 `--color-border-hover`
+- **选中状态**：使用 `--color-selected-bg` 和 `--color-selected-border`
+- **焦点状态**：使用 `--color-focus-ring`
 
 ### 4. 过渡动画
 
-- **快速交互**：使用 `--filter-transition-fast` (0.15s)
-- **常规交互**：使用 `--filter-transition-normal` (0.2s)
-- **慢速交互**：使用 `--filter-transition-slow` (0.3s)
+- **快速交互**：使用 `--transition-fast` (0.15s)
+- **常规交互**：使用 `--transition-normal` (0.2s)
+- **慢速交互**：使用 `--transition-slow` (0.3s)
 
 ## 扩展指南
 
 ### 添加新的设计令牌
 
 1. 在 `src/styles/design-tokens.css` 中添加新令牌
-2. 遵循命名约定：`--filter-[category]-[property]-[variant]`
+2. 遵循命名约定：优先使用三层结构（`--color-*`、`--space-*`、`--button-*` 等语义名称）
 3. 提供语义化的名称而非具体值
 
 ### 创建新的基础组件

--- a/vue-frontend/src/components/commute/TransportModes.vue
+++ b/vue-frontend/src/components/commute/TransportModes.vue
@@ -99,12 +99,12 @@ const selectMode = (value) => {
 }
 
 .mode-btn.active {
-  background: var(--filter-color-neutral-800);
+  background: var(--gray-800);
   color: var(--color-text-inverse);
 }
 
 .mode-btn.active:hover {
-  background: var(--filter-color-neutral-900);
+  background: var(--gray-900);
 }
 
 /* 触摸设备优化 */
@@ -119,7 +119,7 @@ const selectMode = (value) => {
   }
 
   .mode-btn.active:hover {
-    background: var(--filter-color-neutral-800);
+    background: var(--gray-800);
   }
 }
 </style>

--- a/vue-frontend/src/components/filter-panels/AreaFilterPanel.vue
+++ b/vue-frontend/src/components/filter-panels/AreaFilterPanel.vue
@@ -471,14 +471,14 @@ const applyFilters = async () => {
 /* 兼容 BaseChip 子元素命名，保持现有样式生效 */
 /* 默认态加固：使用设计令牌并阻断父级/UA 覆盖（消除浅蓝底） */
 .location-chip :deep(.base-chip__remove) {
-  background: var(--filter-chip-remove-bg) !important;
-  background-color: var(--filter-chip-remove-bg) !important;
+  background: var(--chip-remove-bg) !important;
+  background-color: var(--chip-remove-bg) !important;
   background-image: none !important;
   border: none !important;
-  color: var(--filter-chip-remove-color) !important;
-  width: var(--filter-chip-remove-size);
-  height: var(--filter-chip-remove-size);
-  border-radius: var(--filter-chip-remove-radius);
+  color: var(--chip-remove-color) !important;
+  width: var(--chip-remove-size);
+  height: var(--chip-remove-size);
+  border-radius: var(--chip-remove-radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -486,7 +486,7 @@ const applyFilters = async () => {
   line-height: 1;
   padding: 0;
   cursor: pointer;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
   box-shadow: none !important;
   -webkit-appearance: none;
   appearance: none;
@@ -502,16 +502,16 @@ const applyFilters = async () => {
 /* Hover/Active 采用移除态危险色 */
 .location-chip :deep(.base-chip__remove:hover),
 .location-chip :deep(.base-chip__remove:active) {
-  background: var(--filter-chip-remove-hover-bg) !important;
-  color: var(--filter-chip-remove-hover-color) !important;
+  background: var(--chip-remove-hover-bg) !important;
+  color: var(--chip-remove-hover-color) !important;
 }
 
 /* 选中/焦点保持中性 remove 背景，彻底移除浅蓝底 */
 .location-chip :deep(.base-chip--selected .base-chip__remove),
 .location-chip :deep(.base-chip__remove:focus),
 .location-chip :deep(.base-chip__remove:focus-visible) {
-  background: var(--filter-chip-remove-bg) !important;
-  color: var(--filter-chip-remove-color) !important;
+  background: var(--chip-remove-bg) !important;
+  color: var(--chip-remove-color) !important;
   outline: none !important;
   box-shadow: none !important;
   border: none !important;

--- a/vue-frontend/src/components/filter-panels/AvailabilityFilterPanel.vue
+++ b/vue-frontend/src/components/filter-panels/AvailabilityFilterPanel.vue
@@ -276,21 +276,21 @@ const applyFilters = async () => {
 <style scoped>
 .availability-filter-panel {
   width: 100%;
-  background: var(--filter-panel-bg);
-  border-radius: var(--filter-panel-radius);
+  background: var(--panel-bg);
+  border-radius: var(--panel-radius);
 }
 
 /* 面板内容 */
 .panel-content {
-  padding: var(--filter-panel-padding);
+  padding: var(--panel-padding);
 }
 
 /* 日期选择器 */
 .date-picker-group {
   display: flex;
   align-items: center;
-  gap: var(--filter-space-md);
-  margin-bottom: var(--filter-space-xl);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
 }
 
 .date-picker-start,
@@ -299,9 +299,9 @@ const applyFilters = async () => {
 }
 
 .date-separator {
-  color: var(--filter-color-text-secondary);
-  margin: 0 var(--filter-space-xs);
-  font-weight: var(--filter-font-weight-medium);
+  color: var(--color-text-secondary);
+  margin: 0 var(--space-2xs);
+  font-weight: var(--font-weight-medium);
 }
 
 /* 焦点态：中性灰细边框，移除黑色外框 */
@@ -313,8 +313,8 @@ const applyFilters = async () => {
 /* 收紧日期输入右侧内边距，避免右侧空白过大（改用 Filter Field 令牌，PC 作用域可被局部变量覆盖） */
 :deep(.el-date-editor .el-input__wrapper) {
   padding-right: calc(
-    var(--filter-suffix-right, var(--search-suffix-right, 12px)) +
-      var(--filter-suffix-hit, var(--search-suffix-hit, 28px))
+    var(--search-suffix-right, var(--search-suffix-right, 12px)) +
+      var(--search-suffix-hit, var(--search-suffix-hit, 28px))
   ) !important;
 }
 
@@ -332,11 +332,11 @@ const applyFilters = async () => {
 
 /* 日期错误提示 */
 .date-error {
-  color: var(--filter-color-danger);
-  font-size: var(--filter-font-size-md);
-  margin-top: var(--filter-space-md);
-  margin-bottom: var(--filter-space-xl);
-  font-weight: var(--filter-font-weight-medium);
+  color: var(--color-danger);
+  font-size: var(--font-size-md);
+  margin-top: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  font-weight: var(--font-weight-medium);
 }
 
 /* 底部操作按钮 */

--- a/vue-frontend/src/components/filter-panels/BedroomsFilterPanel.vue
+++ b/vue-frontend/src/components/filter-panels/BedroomsFilterPanel.vue
@@ -349,8 +349,8 @@ const applyFilters = async () => {
 <style scoped>
 .bedrooms-filter-panel {
   width: 100%;
-  background: var(--filter-panel-bg);
-  border-radius: var(--filter-panel-radius);
+  background: var(--panel-bg);
+  border-radius: var(--panel-radius);
 }
 
 /* 面板头部 */
@@ -358,77 +358,77 @@ const applyFilters = async () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--filter-panel-padding);
-  border-bottom: 1px solid var(--filter-panel-header-border);
+  padding: var(--panel-padding);
+  border-bottom: 1px solid var(--panel-header-border);
 }
 
 .panel-title {
-  font-size: var(--filter-panel-title-font-size);
-  font-weight: var(--filter-panel-title-font-weight);
-  color: var(--filter-panel-title-color);
+  font-size: var(--panel-title-font-size);
+  font-weight: var(--panel-title-font-weight);
+  color: var(--panel-title-color);
   margin: 0;
 }
 
 .close-btn {
   background: none;
   border: none;
-  color: var(--filter-close-btn-color);
+  color: var(--panel-close-color);
   cursor: pointer;
-  padding: var(--filter-close-btn-padding);
-  border-radius: var(--filter-close-btn-radius);
+  padding: var(--panel-close-padding);
+  border-radius: var(--panel-close-radius);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
 }
 
 .close-btn:hover {
-  background: var(--filter-close-btn-hover-bg);
-  color: var(--filter-close-btn-hover-color);
+  background: var(--panel-close-hover-bg);
+  color: var(--panel-close-hover-color);
 }
 
 .spec-icon {
-  width: var(--filter-close-btn-size);
-  height: var(--filter-close-btn-size);
+  width: var(--panel-close-size);
+  height: var(--panel-close-size);
 }
 
 /* 面板内容 */
 .panel-content {
-  padding: var(--filter-space-lg); /* 使用设计令牌 */
+  padding: var(--space-md); /* 使用设计令牌 */
 }
 
 /* 筛选按钮组 */
 .filter-buttons-group {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--filter-space-md);
-  margin-bottom: var(--filter-space-xl);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
 }
 
 .filter-btn {
-  padding: var(--filter-space-lg) var(--filter-space-xl);
-  border: 1px solid var(--filter-color-border-default);
-  border-radius: var(--filter-radius-md);
-  background: var(--filter-color-bg-primary);
-  font-size: var(--filter-font-size-md);
-  font-weight: var(--filter-font-weight-medium);
-  color: var(--filter-color-text-primary);
+  padding: var(--space-md) var(--space-lg);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-primary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
   cursor: pointer;
-  transition: var(--filter-transition-normal);
+  transition: var(--transition-normal);
   min-width: 60px;
 }
 
 .filter-btn:hover {
-  border-color: var(--filter-color-hover-border);
-  color: var(--filter-color-text-primary);
-  background: var(--filter-color-hover-bg);
+  border-color: var(--color-border-hover);
+  color: var(--color-text-primary);
+  background: var(--color-surface-hover);
 }
 
 .filter-btn.active {
-  background: var(--filter-color-selected-bg);
-  border-color: var(--filter-color-selected-border);
-  color: var(--filter-color-text-primary);
-  font-weight: var(--filter-font-weight-semibold);
+  background: var(--color-selected-bg);
+  border-color: var(--color-selected-border);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 /* 连体分段样式：保留现有颜色/描边/填充，仅处理连体与圆角 */
@@ -480,14 +480,14 @@ const applyFilters = async () => {
 
 /* 小节标题 */
 .section {
-  margin-top: var(--filter-space-xs);
+  margin-top: var(--space-2xs);
 }
 
 .section-label {
-  font-size: var(--filter-font-size-sm);
-  color: var(--filter-color-text-secondary);
-  margin-bottom: var(--filter-space-md);
-  font-weight: var(--filter-font-weight-medium);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-sm);
+  font-weight: var(--font-weight-medium);
 }
 
 /* 屏幕阅读器可见性辅助 */

--- a/vue-frontend/src/components/filter-panels/MoreFilterPanel.vue
+++ b/vue-frontend/src/components/filter-panels/MoreFilterPanel.vue
@@ -162,8 +162,8 @@ const apply = async () => {
 <style scoped>
 .more-filter-panel {
   width: 100%;
-  background: var(--filter-panel-bg);
-  border-radius: var(--filter-panel-radius);
+  background: var(--panel-bg);
+  border-radius: var(--panel-radius);
 }
 
 /* 头部 */
@@ -171,56 +171,56 @@ const apply = async () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--filter-panel-padding);
-  border-bottom: 1px solid var(--filter-panel-header-border);
+  padding: var(--panel-padding);
+  border-bottom: 1px solid var(--panel-header-border);
 }
 
 .panel-title {
-  font-size: var(--filter-panel-title-font-size);
-  font-weight: var(--filter-panel-title-font-weight);
-  color: var(--filter-panel-title-color);
+  font-size: var(--panel-title-font-size);
+  font-weight: var(--panel-title-font-weight);
+  color: var(--panel-title-color);
   margin: 0;
 }
 
 .close-btn {
   background: none;
   border: none;
-  color: var(--filter-close-btn-color);
+  color: var(--panel-close-color);
   cursor: pointer;
-  padding: var(--filter-close-btn-padding);
-  border-radius: var(--filter-close-btn-radius);
+  padding: var(--panel-close-padding);
+  border-radius: var(--panel-close-radius);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
 }
 
 .close-btn:hover {
-  background: var(--filter-close-btn-hover-bg);
-  color: var(--filter-close-btn-hover-color);
+  background: var(--panel-close-hover-bg);
+  color: var(--panel-close-hover-color);
 }
 
 .spec-icon {
-  width: var(--filter-close-btn-size);
-  height: var(--filter-close-btn-size);
+  width: var(--panel-close-size);
+  height: var(--panel-close-size);
 }
 
 /* 内容 */
 .panel-content {
-  padding: var(--filter-panel-padding);
+  padding: var(--panel-padding);
 }
 
 .form-row {
   display: flex;
   flex-direction: column;
-  gap: var(--filter-space-md);
-  margin-bottom: var(--filter-space-xl);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
 }
 
 .form-label {
-  font-size: var(--filter-font-size-sm);
-  color: var(--filter-color-text-secondary);
-  font-weight: var(--filter-font-weight-medium);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-medium);
 }
 
 /* 底部操作 */

--- a/vue-frontend/src/components/filter-panels/PriceFilterPanel.vue
+++ b/vue-frontend/src/components/filter-panels/PriceFilterPanel.vue
@@ -275,8 +275,8 @@ const applyFilters = async () => {
 <style scoped>
 .price-filter-panel {
   width: 100%;
-  background: var(--filter-panel-bg);
-  border-radius: var(--filter-panel-radius);
+  background: var(--panel-bg);
+  border-radius: var(--panel-radius);
 }
 
 /* 面板头部 */
@@ -284,54 +284,54 @@ const applyFilters = async () => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--filter-panel-padding);
-  border-bottom: 1px solid var(--filter-panel-header-border);
+  padding: var(--panel-padding);
+  border-bottom: 1px solid var(--panel-header-border);
 }
 
 .panel-title {
-  font-size: var(--filter-panel-title-font-size);
-  font-weight: var(--filter-panel-title-font-weight);
-  color: var(--filter-panel-title-color);
+  font-size: var(--panel-title-font-size);
+  font-weight: var(--panel-title-font-weight);
+  color: var(--panel-title-color);
   margin: 0;
 }
 
 .close-btn {
   background: none;
   border: none;
-  color: var(--filter-close-btn-color);
+  color: var(--panel-close-color);
   cursor: pointer;
-  padding: var(--filter-close-btn-padding);
-  border-radius: var(--filter-close-btn-radius);
+  padding: var(--panel-close-padding);
+  border-radius: var(--panel-close-radius);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: var(--filter-transition-fast);
+  transition: var(--transition-fast);
 }
 
 .close-btn:hover {
-  background: var(--filter-close-btn-hover-bg);
-  color: var(--filter-close-btn-hover-color);
+  background: var(--panel-close-hover-bg);
+  color: var(--panel-close-hover-color);
 }
 
 .spec-icon {
-  width: var(--filter-close-btn-size);
-  height: var(--filter-close-btn-size);
+  width: var(--panel-close-size);
+  height: var(--panel-close-size);
 }
 
 /* 面板内容 */
 .panel-content {
-  padding: var(--filter-panel-padding);
+  padding: var(--panel-padding);
 }
 
 /* 价格范围标题 */
 .price-range-header {
-  margin-bottom: var(--filter-space-lg);
+  margin-bottom: var(--space-md);
 }
 
 .price-range-title {
-  font-size: var(--filter-font-size-md);
-  font-weight: var(--filter-font-weight-semibold);
-  color: var(--filter-color-text-primary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
   margin: 0;
 }
 
@@ -339,22 +339,22 @@ const applyFilters = async () => {
 .price-selectors-horizontal {
   display: flex;
   align-items: flex-end;
-  gap: var(--filter-space-md);
-  margin-bottom: var(--filter-space-xl);
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
 }
 
 .price-selector-group {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: var(--filter-space-sm);
+  gap: var(--space-xs);
 }
 
 .selector-label {
-  font-size: var(--filter-font-size-sm);
-  font-weight: var(--filter-font-weight-medium);
-  color: var(--filter-color-text-secondary);
-  margin-bottom: var(--filter-space-xs);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-2xs);
 }
 
 .price-select {
@@ -363,11 +363,11 @@ const applyFilters = async () => {
 
 /* 价格分隔符 */
 .price-separator {
-  color: var(--filter-color-text-secondary);
-  font-size: var(--filter-font-size-md);
-  font-weight: var(--filter-font-weight-medium);
-  padding: 0 var(--filter-space-xs);
-  margin-bottom: var(--filter-space-xs);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  padding: 0 var(--space-2xs);
+  margin-bottom: var(--space-2xs);
   display: flex;
   align-items: center;
   height: 40px; /* 与下拉框高度对齐 */
@@ -375,14 +375,14 @@ const applyFilters = async () => {
 
 /* Element Plus 下拉选择器样式定制 */
 .price-select :deep(.el-input__wrapper) {
-  border: 1px solid var(--filter-color-border-default);
-  border-radius: var(--filter-radius-md);
-  background: var(--filter-color-bg-primary);
-  transition: var(--filter-transition-normal);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-primary);
+  transition: var(--transition-normal);
 }
 
 .price-select :deep(.el-input__wrapper:hover) {
-  border-color: var(--filter-color-hover-border);
+  border-color: var(--color-border-hover);
 }
 
 .price-select :deep(.el-input__wrapper.is-focus) {
@@ -391,27 +391,27 @@ const applyFilters = async () => {
 }
 
 .price-select :deep(.el-input__inner) {
-  color: var(--filter-color-text-primary);
-  font-size: var(--filter-font-size-md);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
 }
 
 .price-select :deep(.el-input__inner::placeholder) {
-  color: var(--filter-color-text-secondary);
+  color: var(--color-text-secondary);
 }
 
 /* 价格显示区域 */
 .price-display {
-  margin: var(--filter-space-md) 0;
-  padding: var(--filter-space-md);
-  background: var(--filter-color-bg-secondary);
-  border-radius: var(--filter-radius-md);
-  border: 1px solid var(--filter-color-border-default);
+  margin: var(--space-sm) 0;
+  padding: var(--space-sm);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-xs);
+  border: 1px solid var(--color-border-default);
 }
 
 .price-range-text {
-  font-size: var(--filter-font-size-md);
-  font-weight: var(--filter-font-weight-medium);
-  color: var(--filter-color-text-primary);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
 }
 
 /* sr-only 用于无障碍播报 */

--- a/vue-frontend/src/components/modals/AuthModal.vue
+++ b/vue-frontend/src/components/modals/AuthModal.vue
@@ -291,13 +291,13 @@ const handleFacebookAuth = () => {
   font-weight: 600;
   border-radius: 8px;
   margin-top: 24px;
-  background: var(--filter-color-danger) !important;
-  border-color: var(--filter-color-danger) !important;
+  background: var(--color-danger) !important;
+  border-color: var(--color-danger) !important;
 }
 
 .submit-btn:hover {
-  background: var(--filter-color-danger-hover) !important;
-  border-color: var(--filter-color-danger-hover) !important;
+  background: var(--color-danger-hover) !important;
+  border-color: var(--color-danger-hover) !important;
 }
 
 .switch-mode {
@@ -308,7 +308,7 @@ const handleFacebookAuth = () => {
 }
 
 .switch-link {
-  color: var(--filter-color-danger);
+  color: var(--color-danger);
   cursor: pointer;
   font-weight: 600;
   margin-left: 4px;
@@ -368,7 +368,7 @@ const handleFacebookAuth = () => {
 
 .social-btn:hover {
   background: var(--surface-2);
-  border-color: var(--filter-color-border-strong);
+  border-color: var(--color-border-strong);
 }
 
 .social-btn i {

--- a/vue-frontend/src/components/modals/EmailVerifyModal.vue
+++ b/vue-frontend/src/components/modals/EmailVerifyModal.vue
@@ -316,7 +316,7 @@ onUnmounted(() => {
 .resend-link {
   background: none;
   border: none;
-  color: var(--filter-color-danger);
+  color: var(--color-danger);
   font-size: 14px;
   font-weight: 600;
   cursor: pointer;

--- a/vue-frontend/src/style.css
+++ b/vue-frontend/src/style.css
@@ -5,163 +5,7 @@
 @import './styles/typography.css';
 @import './styles/page-tokens.css';
 
-/* 新增：品牌蓝色与专业中性灰阶（基础层 tokens）
-   中文注释：提供统一的蓝色品牌色族与中性灰阶，作为基础令牌被全站复用。
-   注意：仅新增变量，不改变现有样式的引用，保证向后兼容与可回滚。 */
-:root {
-  /* 品牌蓝色族（来源：用户提供） */
-  --blue-50: #e3f2fd;
-  --blue-100: #bbdefb;
-  --blue-200: #90caf9;
-  --blue-300: #64b5f6;
-  --blue-400: #42a5f5;
-  --blue-500: #2196f3;
-  --blue-600: #1e88e5;
-  --blue-700: #1976d2;
-  --blue-800: #1565c0;
-  --blue-900: #0d47a1;
-
-  /* 专业中性灰阶（与筛选面板灰阶保持一致，统一全站风格） */
-  --neutral-50: #f9fafb;
-  --neutral-100: #f3f4f6;
-  --neutral-200: #e5e7eb;
-  --neutral-300: #d1d5db;
-  --neutral-400: #9ca3af;
-  --neutral-500: #6b7280;
-  --neutral-600: #4b5563;
-  --neutral-700: #374151;
-  --neutral-800: #1f2937;
-  --neutral-900: #111827;
-}
-
-/* ========== JUWO品牌色彩系统 ========== */
-:root {
-  /* JUWO主品牌色替换为品牌蓝（语义别名，不改历史变量名，便于向后兼容）
-     中文注释：保持现有 --juwo-* 变量名不变，仅把值映射到新的品牌蓝色。
-     受影响的“前端表现”：主按钮/链接/导航 hover 将切换为蓝色系，其它中性样式不变。 */
-  /* 调整为更深主色：默认 800，hover/active 到 900（中文注释：更沉稳的蓝） */
-  --juwo-primary: #0057ff;
-  --juwo-primary-light: #0047e5;
-  --juwo-primary-dark: #0036b3;
-  --juwo-primary-50: var(--blue-50);
-  --juwo-primary-100: var(--blue-100);
-  --juwo-primary-500: var(--blue-500);
-  --juwo-primary-600: var(--blue-600);
-  --juwo-primary-700: var(--blue-700);
-
-  /* Element Plus主题定制（中性化 primary，保留按钮用 juwo-primary） */
-  --el-color-primary: #5b6472;
-  --el-color-primary-light-1: #6b7583;
-  --el-color-primary-light-3: #8a93a0;
-  --el-color-primary-light-5: #c7ccd3;
-  --el-color-primary-light-7: #e6e9ed;
-  --el-color-primary-light-8: #eff1f4;
-  --el-color-primary-light-9: #f7f8fa;
-  --el-color-primary-dark-2: #3c475b;
-
-  /* 从现有设计系统继承的颜色 */
-  --color-text-primary: #2d2d2d;
-  --color-text-secondary: #595959;
-  --color-text-price: var(--color-text-primary); /* deprecated alias: do not use in business code */
-  --color-border-default: #e3e3e3;
-  --color-bg-page: #f4f7f9;
-  --color-bg-card: #ffffff;
-
-  /* 专业字体系统 */
-  --font-english: 'SF Pro Text', -apple-system, 'Segoe UI', Roboto, sans-serif;
-  --font-chinese:
-    'PingFang SC', 'Noto Sans CJK SC', 'Source Han Sans SC', 'Microsoft YaHei', sans-serif;
-  --font-system: -apple-system, 'PingFang SC', 'Inter', sans-serif;
-
-  /* 专业间距系统 */
-  --space-xs: 4px;
-  --space-sm: 8px;
-  --space-md: 16px;
-  --space-lg: 24px;
-  --space-xl: 32px;
-  --space-2xl: 48px;
-
-  /* 专业阴影系统 */
-  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
-
-  /* 专业圆角系统 */
-  --radius-sm: 8px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --radius-xl: 20px;
-}
-
-/* ========== 统一补充：详情页引用的设计令牌，映射到全局变量（不影响现有页面） ========== */
-:root {
-  /* 间距（对齐 Tailwind 语义，用于详情页按钮/栅格） */
-  --space-1-5: 6px; /* 0.375rem */
-  --space-3: 12px; /* 0.75rem */
-  --space-3-5: 14px; /* 0.875rem */
-  --space-4: 16px; /* 1rem */
-  --space-6: 24px; /* 1.5rem */
-
-  /* 字体与字重（详情页使用到的变量名） */
-  --text-xs: 12px;
-  --text-sm: 14px;
-  --text-base: 16px;
-  --text-lg: 18px;
-  --font-semibold: 600;
-
-  /* 背景/边框/品牌（映射到现有JUWO设计系统） */
-  --bg-base: var(--color-bg-card);
-  --bg-hover: #f7f8fa;
-  --bg-secondary: var(--juwo-primary-50);
-  --radius-full: 9999px;
-  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --brand-primary: var(--juwo-primary);
-
-  /* 文本与链接颜色（与全局一致） */
-  --text-primary: var(--color-text-primary);
-  --text-tertiary: #8b8f97;
-  /* 链接默认更浅一档以保证可读性层级 */
-  --link-color: #0057ff;
-  --link-hover-color: #0047e5;
-
-  /* 输入框后缀定位令牌（统一管理） */
-  --search-suffix-right: 12px; /* 图标距输入框右边界 */
-  --search-suffix-hit: 32px; /* 命中区域尺寸，必要时可收紧为 24–28px */
-
-  /* Chip 中性化令牌（全站复用） */
-  --chip-bg: #f7f8fa;
-  --chip-bg-hover: #eef1f4;
-  --chip-bg-selected: #e9eef2;
-
-  /* 叠加遮罩令牌（统一管理透明度） */
-  --overlay-light-90: rgba(255, 255, 255, 0.9);
-  --overlay-dark-75: rgba(0, 0, 0, 0.75);
-
-  /* 新增：通用弱底与弱文本令牌（中文注释：替代零散 #f5f5f5/#f0f2f5/#e8e8e8/#999；不改旧值，确保向后兼容） */
-  --surface-2: #f5f5f5;
-  --surface-3: #f0f2f5;
-  --surface-4: #e8e8e8;
-  --text-muted: #999999;
-}
-
-:root {
-  /* 语义状态与品牌补充令牌（仅新增，不影响现有样式；用于替换历史硬编码）
-     前端表现：错误/警告/成功/收藏/社交色统一来源，方便全站联动 */
-  --semantic-danger: #dc2626;
-  --semantic-danger-hover: #b91c1c;
-
-  --semantic-warning: #f59e0b;
-  --semantic-warning-weak: #fff3cd;
-
-  --semantic-success: #6fc168;
-
-  --semantic-favorite: #ffd700;
-  --semantic-favorite-hover: #ffed4e;
-
-  --brand-google: #ea4335;
-  --brand-facebook: #1877f2;
-}
+/* 设计令牌均在 styles/design-tokens.css 中统一维护。 */
 
 /* ========== 全局重置样式 ========== */
 * {
@@ -1391,13 +1235,6 @@ header nav .el-menu-item:hover,
    说明：统一筛选输入尺寸/间距/字体与后缀命中区，避免逐面板打补丁
 */
 :root {
-  --filter-field-height-pc: 40px;
-  --filter-field-height-mob: 44px;
-  --filter-field-font-pc: 14px;
-  --filter-field-font-mob: 16px; /* iOS 防缩放阈值 */
-  --filter-field-padding-x: 12px;
-  --filter-suffix-right: 12px; /* 若未定义则回退到 --search-suffix-right */
-  --filter-suffix-hit: 28px; /* 若未定义则回退到 --search-suffix-hit */
   --date-field-min-ch: 12ch; /* YYYY-MM-DD 10ch 留余量，避免挤压 */
 }
 
@@ -1407,8 +1244,8 @@ header nav .el-menu-item:hover,
   height: var(--filter-field-height-pc) !important;
   padding-left: var(--filter-field-padding-x) !important;
   padding-right: calc(
-    var(--filter-suffix-right, var(--search-suffix-right, 12px)) +
-      var(--filter-suffix-hit, var(--search-suffix-hit, 28px))
+    var(--search-suffix-right, var(--search-suffix-right, 12px)) +
+      var(--search-suffix-hit, var(--search-suffix-hit, 28px))
   ) !important;
   padding-top: 0 !important;
   padding-bottom: 0 !important;
@@ -1425,11 +1262,11 @@ header nav .el-menu-item:hover,
 
 /* PC 分离式下拉：收紧后缀命中区与左右内边距，仅限筛选容器
    说明：不改变容器宽度，仅通过内/外边距与后缀点击区瘦身，释放文本空间
-   风险可回滚：--filter-suffix-right 恢复 12px；--filter-suffix-hit 恢复 28px；删除本段覆盖
+   风险可回滚：--search-suffix-right 恢复 12px；--search-suffix-hit 恢复 28px；删除本段覆盖
 */
 .filter-dropdown-container {
-  --filter-suffix-right: 8px; /* 收紧右侧内距：x到右边界更近 */
-  --filter-suffix-hit: 20px; /* 收紧命中区，仍可点击 */
+  --search-suffix-right: 8px; /* 收紧右侧内距：x到右边界更近 */
+  --search-suffix-hit: 20px; /* 收紧命中区，仍可点击 */
   --date-field-min-ch: 10ch; /* PC面板内日期最小字符宽 */
 }
 
@@ -1441,8 +1278,8 @@ header nav .el-menu-item:hover,
 
 /* 后缀区域尺寸与右内边距（仅 PC Filter 作用域） */
 .filter-dropdown-container .filter-field :deep(.el-input__suffix) {
-  width: var(--filter-suffix-hit);
-  padding-right: var(--filter-suffix-right);
+  width: var(--search-suffix-hit);
+  padding-right: var(--search-suffix-right);
 }
 /* 收紧后缀内部间距（清除 x 与图标组之间的多余空隙） */
 .filter-dropdown-container .filter-field :deep(.el-input__suffix-inner) {
@@ -1494,12 +1331,12 @@ header nav .el-menu-item:hover,
 }
 
 .chinese-text {
-  font-family: var(--font-chinese);
+  font-family: var(--font-family-zh-sans);
   letter-spacing: 0.02em;
 }
 
 .english-text {
-  font-family: var(--font-english);
+  font-family: var(--font-family-en-sans);
   letter-spacing: -0.01em;
 }
 

--- a/vue-frontend/src/styles/design-tokens.css
+++ b/vue-frontend/src/styles/design-tokens.css
@@ -1,348 +1,501 @@
 /**
- * 设计令牌系统 - Sydney Rental Hub
- * 基于区域筛选面板现代化设计的成功模式提取
- *
- * 设计原则：
- * - 中性灰色调，避免过度品牌化
- * - 微妙的圆角 (4-6px)，现代但不过分
- * - 一致的间距系统
- * - 清晰的层次结构
+ * Sydney Rental Hub – Design Tokens
+ * --------------------------------------------------------------------------
+ * 单一事实来源（Single Source of Truth）
+ * 结构：
+ *   Tier 1  原始令牌（Primitive Tokens）    -> 物理值（颜色、尺寸等）
+ *   Tier 2  语义令牌（Semantic Tokens）     -> 业务语义，引用 Tier 1
+ *   Tier 3  组件令牌（Component Tokens）    -> 组件/模式专用，引用 Tier 2
  */
 
 :root {
-  /* ========== 颜色系统 ========== */
+  /* ---------------------------------------------------------------------- */
+  /* Tier 1 · Primitive Tokens (原始令牌：仅包含物理值)                     */
+  /* ---------------------------------------------------------------------- */
 
-  /* 中性灰色调 - 主要用于筛选面板 */
-  --filter-color-neutral-50: #f9fafb;
-  --filter-color-neutral-100: #f3f4f6;
-  --filter-color-neutral-200: #e5e7eb;
-  --filter-color-neutral-300: #d1d5db;
-  --filter-color-neutral-400: #9ca3af;
-  --filter-color-neutral-500: #6b7280;
-  --filter-color-neutral-600: #4b5563;
-  --filter-color-neutral-700: #374151;
-  --filter-color-neutral-800: #1f2937;
-  --filter-color-neutral-900: #111827;
+  /* 基础颜色值 */
+  --color-white: #ffffff;
+  --color-black: #000000;
 
-  /* 语义化颜色 */
-  --filter-color-bg-primary: #ffffff;
-  --filter-color-bg-secondary: var(--filter-color-neutral-50);
-  --filter-color-bg-muted: var(--filter-color-neutral-100);
+  /* 中性灰阶 */
+  --gray-50: #f9fafb;
+  --gray-75: #f4f7f9; /* 页面背景常用的柔和灰 */
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
+  --gray-700: #374151;
+  --gray-800: #1f2937;
+  --gray-900: #111827;
 
-  --filter-color-text-primary: var(--filter-color-neutral-800);
-  --filter-color-text-secondary: var(--filter-color-neutral-500);
-  --filter-color-text-muted: var(--filter-color-neutral-400);
+  /* 品牌蓝阶（原桔屋品牌色族） */
+  --blue-50: #e3f2fd;
+  --blue-100: #bbdefb;
+  --blue-200: #90caf9;
+  --blue-300: #64b5f6;
+  --blue-400: #42a5f5;
+  --blue-500: #2196f3;
+  --blue-600: #1e88e5;
+  --blue-700: #1976d2;
+  --blue-800: #1565c0;
+  --blue-900: #0d47a1;
 
-  --filter-color-border-default: var(--filter-color-neutral-300);
-  --filter-color-border-strong: var(--filter-color-neutral-400);
-  --filter-color-border-subtle: var(--filter-color-neutral-200);
+  /* 品牌主色（更沉稳的租房蓝） */
+  --brand-blue-400: #0047e5;
+  --brand-blue-500: #0057ff;
+  --brand-blue-600: #0036b3;
 
-  /* 交互状态颜色 */
-  --filter-color-hover-bg: var(--filter-color-neutral-50);
-  --filter-color-hover-border: var(--filter-color-neutral-400);
-  --filter-color-focus-ring: rgba(107, 114, 128, 0.1);
-  --filter-color-selected-bg: var(--filter-color-neutral-100);
-  --filter-color-selected-border: var(--filter-color-neutral-300);
+  /* 功能色基准 */
+  --red-600: #dc2626;
+  --red-700: #b91c1c;
+  --green-500: #16a34a;
+  --amber-500: #f59e0b;
+  --cyan-500: #0ea5e9;
 
-  /* 危险/移除操作颜色 */
-  --filter-color-danger: #dc2626;
-  --filter-color-danger-hover: #b91c1c;
+  /* 半透明色值 */
+  --gray-500-10: rgba(107, 114, 128, 0.1); /* focus ring */
+  --overlay-white-90: rgba(255, 255, 255, 0.9);
+  --overlay-black-75: rgba(0, 0, 0, 0.75);
 
-  /* ========== 间距系统 ========== */
+  /* 尺寸基线（px） */
+  --size-2: 2px;
+  --size-3: 3px;
+  --size-4: 4px;
+  --size-6: 6px;
+  --size-8: 8px;
+  --size-10: 10px;
+  --size-11: 11px;
+  --size-12: 12px;
+  --size-13: 13px;
+  --size-14: 14px;
+  --size-15: 15px;
+  --size-16: 16px;
+  --size-18: 18px;
+  --size-20: 20px;
+  --size-22: 22px;
+  --size-24: 24px;
+  --size-28: 28px;
+  --size-32: 32px;
+  --size-36: 36px;
+  --size-40: 40px;
+  --size-44: 44px;
+  --size-48: 48px;
+  --size-56: 56px;
+  --size-64: 64px;
+  --size-280: 280px;
+  --size-580: 580px; /* 房源卡片基准宽度 */
 
-  --filter-space-xs: 4px;
-  --filter-space-sm: 6px;
-  --filter-space-md: 8px;
-  --filter-space-lg: 12px;
-  --filter-space-xl: 16px;
-  --filter-space-2xl: 20px;
-  --filter-space-3xl: 24px;
+  /* 字重与行高 */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
 
-  /* ========== 圆角系统 ========== */
+  --leading-tight: 1.2;
+  --leading-normal: 1.4;
+  --leading-relaxed: 1.6;
+  --leading-loose: 1.8;
 
-  --filter-radius-none: 0;
-  --filter-radius-sm: 2px;
-  --filter-radius-md: 4px;
-  --filter-radius-lg: 6px;
-  --filter-radius-xl: 8px;
+  /* 阴影基线 */
+  --shadow-100: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-200: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-300: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-400: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0 10px 10px -5px rgba(0, 0, 0, 0.04);
 
-  /* ========== 字体系统 ========== */
+  /* 动效时长与缓动 */
+  --duration-120: 0.12s;
+  --duration-150: 0.15s;
+  --duration-180: 0.18s;
+  --duration-200: 0.2s;
+  --duration-300: 0.3s;
+  --easing-standard: cubic-bezier(0.2, 0, 0, 1);
 
-  --filter-font-size-xs: 11px;
-  --filter-font-size-sm: 13px;
-  --filter-font-size-md: 14px;
-  --filter-font-size-lg: 16px;
-  --filter-font-size-xl: 18px;
-
-  --filter-font-weight-normal: 400;
-  --filter-font-weight-medium: 500;
-  --filter-font-weight-semibold: 600;
-  --filter-font-weight-bold: 700;
-
-  --filter-line-height-tight: 1.2;
-  --filter-line-height-normal: 1.4;
-  --filter-line-height-relaxed: 1.6;
-
-  /* ========== 阴影系统 ========== */
-
-  --filter-shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-  --filter-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --filter-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --filter-shadow-focus: 0 0 0 3px var(--filter-color-focus-ring);
-
-  /* ========== 过渡动画 ========== */
-
-  --filter-transition-fast: 0.15s ease;
-  --filter-transition-normal: 0.2s ease;
-  --filter-transition-slow: 0.3s ease;
-
-  /* ========== 组件特定令牌 ========== */
-
-  /* Chip 组件 */
-  --filter-chip-bg: var(--filter-color-bg-secondary);
-  --filter-chip-border: var(--filter-color-border-default);
-  --filter-chip-text: var(--filter-color-text-primary);
-  --filter-chip-hover-bg: var(--filter-color-bg-muted);
-  --filter-chip-hover-border: var(--filter-color-border-strong);
-  --filter-chip-padding-x: 10px;
-  --filter-chip-padding-y: 6px;
-  --filter-chip-gap: var(--filter-space-md);
-  --filter-chip-radius: var(--filter-radius-md);
-  --filter-chip-font-size: var(--filter-font-size-sm);
-  --filter-chip-font-weight: var(--filter-font-weight-medium);
-
-  /* Chip 移除按钮 */
-  --filter-chip-remove-size: 16px;
-  --filter-chip-remove-bg: var(--filter-color-neutral-200);
-  --filter-chip-remove-color: var(--filter-color-text-secondary);
-  --filter-chip-remove-hover-bg: var(--filter-color-danger);
-  --filter-chip-remove-hover-color: #ffffff;
-  --filter-chip-remove-radius: var(--filter-radius-sm);
-
-  /* 搜索输入框 */
-  --filter-search-padding-x: 16px;
-  --filter-search-padding-y: 12px;
-  --filter-search-padding-left: 40px; /* 为搜索图标留空间 */
-  --filter-search-font-size: var(--filter-font-size-md);
-  --filter-search-radius: var(--filter-radius-lg);
-  --filter-search-border: var(--filter-color-border-default);
-  --filter-search-focus-border: var(--filter-color-text-secondary);
-  --filter-search-hover-border: var(--filter-color-border-strong);
-
-  /* 搜索图标 */
-  --filter-search-icon-left: 12px;
-  --filter-search-icon-size: 16px;
-  --filter-search-icon-color: var(--filter-color-text-secondary);
-
-  /* 清除按钮 */
-  --filter-clear-btn-right: 8px;
-  --filter-clear-btn-size: 14px;
-  --filter-clear-btn-padding: 4px;
-  --filter-clear-btn-radius: var(--filter-radius-md);
-  --filter-clear-btn-hover-bg: var(--filter-color-bg-muted);
-
-  /* 按钮系统 */
-  --filter-btn-padding-x: 16px;
-  --filter-btn-padding-y: 12px;
-  --filter-btn-font-size: var(--filter-font-size-md);
-  --filter-btn-font-weight: var(--filter-font-weight-medium);
-  --filter-btn-radius: var(--filter-radius-lg);
-  --filter-btn-gap: var(--filter-space-lg);
-
-  /* 主要按钮 */
-  --filter-btn-primary-bg: var(--juwo-primary);
-  --filter-btn-primary-color: #ffffff;
-  --filter-btn-primary-hover-bg: var(--juwo-primary-light);
-
-  /* 次要按钮 */
-  --filter-btn-secondary-bg: var(--filter-color-bg-primary);
-  --filter-btn-secondary-color: var(--filter-color-text-secondary);
-  --filter-btn-secondary-border: var(--filter-color-border-default);
-  --filter-btn-secondary-hover-border: var(--filter-color-border-strong);
-  --filter-btn-secondary-hover-color: var(--filter-color-text-primary);
-
-  /* 列表项 */
-  --filter-list-item-padding-x: var(--filter-space-xl);
-  --filter-list-item-padding-y: 14px;
-  --filter-list-item-min-height: 48px;
-  --filter-list-item-border: var(--filter-color-border-subtle);
-  --filter-list-item-hover-bg: var(--filter-color-hover-bg);
-  --filter-list-item-selected-bg: var(--filter-color-selected-bg);
-  --filter-list-item-selected-border: var(--filter-color-selected-border);
-
-  /* 复选框 */
-  --filter-checkbox-size: 18px;
-  --filter-checkbox-radius: 3px;
-  --filter-checkbox-accent: var(--filter-color-text-secondary);
-
-  /* 面板系统 */
-  --filter-panel-bg: var(--filter-color-bg-primary);
-  --filter-panel-radius: var(--filter-radius-xl);
-  --filter-panel-padding: var(--filter-space-xl);
-  --filter-panel-header-border: var(--filter-color-border-default);
-  --filter-panel-footer-border: var(--filter-color-border-default);
-
-  /* 面板标题 */
-  --filter-panel-title-font-size: var(--filter-font-size-lg);
-  --filter-panel-title-font-weight: var(--filter-font-weight-semibold);
-  --filter-panel-title-color: var(--filter-color-text-primary);
-
-  /* 关闭按钮 */
-  --filter-close-btn-size: 20px;
-  --filter-close-btn-padding: var(--filter-space-xs);
-  --filter-close-btn-radius: var(--filter-radius-md);
-  --filter-close-btn-color: var(--filter-color-text-secondary);
-  --filter-close-btn-hover-bg: var(--filter-color-hover-bg);
-  --filter-close-btn-hover-color: var(--filter-color-text-primary);
-
-  /* 空状态 */
-  --filter-empty-bg: var(--filter-color-bg-secondary);
-  --filter-empty-border: var(--filter-color-border-subtle);
-  --filter-empty-radius: var(--filter-radius-xl);
-  --filter-empty-padding-x: var(--filter-space-xl);
-  --filter-empty-padding-y: var(--filter-space-2xl);
-  --filter-empty-text-color: var(--filter-color-text-secondary);
-  --filter-empty-font-size: var(--filter-font-size-md);
-  --filter-empty-font-weight: var(--filter-font-weight-medium);
-
-  /* 分组标题 */
-  --filter-group-title-bg: var(--filter-color-bg-secondary);
-  --filter-group-title-padding-x: var(--filter-space-xl);
-  --filter-group-title-padding-y: var(--filter-space-md);
-  --filter-group-title-font-size: var(--filter-font-size-sm);
-  --filter-group-title-font-weight: var(--filter-font-weight-semibold);
-  --filter-group-title-color: var(--filter-color-text-primary);
-  --filter-group-title-border: var(--filter-color-border-subtle);
-
-  /* 操作链接 */
-  --filter-action-link-color: var(--filter-color-text-secondary);
-  --filter-action-link-font-size: var(--filter-font-size-sm);
-  --filter-action-link-font-weight: var(--filter-font-weight-medium);
-  --filter-action-link-padding-x: var(--filter-space-lg);
-  --filter-action-link-padding-y: var(--filter-space-sm);
-  --filter-action-link-radius: var(--filter-radius-lg);
-  --filter-action-link-hover-bg: var(--filter-color-hover-bg);
-  --filter-action-link-hover-color: var(--filter-color-text-primary);
+  /* 字体家族基准 */
+  --font-zh-base: 'PingFang SC', 'Noto Sans SC', 'Source Han Sans SC',
+    'Microsoft YaHei', system-ui, sans-serif;
+  --font-en-base: 'Inter', 'SF Pro Text', 'Segoe UI', Roboto, system-ui,
+    sans-serif;
+  --font-system-base: -apple-system, BlinkMacSystemFont, 'PingFang SC',
+    'Inter', sans-serif;
 }
 
-/* ========== 实用工具类 ========== */
-
-/* 中性颜色工具类 */
-.filter-text-primary {
-  color: var(--filter-color-text-primary);
-}
-.filter-text-secondary {
-  color: var(--filter-color-text-secondary);
-}
-.filter-text-muted {
-  color: var(--filter-color-text-muted);
-}
-
-.filter-bg-primary {
-  background-color: var(--filter-color-bg-primary);
-}
-.filter-bg-secondary {
-  background-color: var(--filter-color-bg-secondary);
-}
-.filter-bg-muted {
-  background-color: var(--filter-color-bg-muted);
-}
-
-.filter-border-default {
-  border-color: var(--filter-color-border-default);
-}
-.filter-border-strong {
-  border-color: var(--filter-color-border-strong);
-}
-.filter-border-subtle {
-  border-color: var(--filter-color-border-subtle);
-}
-
-/* 间距工具类 */
-.filter-space-xs {
-  gap: var(--filter-space-xs);
-}
-.filter-space-sm {
-  gap: var(--filter-space-sm);
-}
-.filter-space-md {
-  gap: var(--filter-space-md);
-}
-.filter-space-lg {
-  gap: var(--filter-space-lg);
-}
-.filter-space-xl {
-  gap: var(--filter-space-xl);
-}
-
-/* 圆角工具类 */
-.filter-radius-sm {
-  border-radius: var(--filter-radius-sm);
-}
-.filter-radius-md {
-  border-radius: var(--filter-radius-md);
-}
-.filter-radius-lg {
-  border-radius: var(--filter-radius-lg);
-}
-.filter-radius-xl {
-  border-radius: var(--filter-radius-xl);
-}
-
-/* 过渡工具类 */
-.filter-transition-fast {
-  transition: all var(--filter-transition-fast);
-}
-.filter-transition-normal {
-  transition: all var(--filter-transition-normal);
-}
-.filter-transition-slow {
-  transition: all var(--filter-transition-slow);
-}
-
-/* ====== Global semantic color tokens (added, non-breaking) ======
-   中文注释：全局语义色令牌，仅“新增不改旧值”，为组件与页面提供统一入口；
-   允许继续沿用现有 var(--color-*) / var(--juwo-*)，本区用于补齐 visited/disabled 与反馈语义色等。
-*/
 :root {
-  /* 反色文本与弱底 */
-  --color-text-inverse: #ffffff;
-  --bg-muted: var(--neutral-50);
+  /* ---------------------------------------------------------------------- */
+  /* Tier 2 · Semantic Tokens (语义令牌：引用原始令牌)                      */
+  /* ---------------------------------------------------------------------- */
 
-  /* 链接态（补齐 visited/disabled） */
-  --link-visited: #0036b3; /* 品牌蓝加深一档，保证可访问性 */
+  /* 品牌与别名 */
+  --brand-primary: var(--brand-blue-500);
+  --brand-primary-hover: var(--brand-blue-400);
+  --brand-primary-active: var(--brand-blue-600);
+  --brand-primary-light: var(--blue-100);
+
+  --juwo-primary: var(--brand-primary);
+  --juwo-primary-light: var(--brand-primary-hover);
+  --juwo-primary-dark: var(--brand-primary-active);
+  --juwo-primary-50: var(--blue-50);
+  --juwo-primary-100: var(--blue-100);
+  --juwo-primary-500: var(--blue-500);
+  --juwo-primary-600: var(--blue-600);
+  --juwo-primary-700: var(--blue-700);
+
+  /* Element Plus 主题中性色调 */
+  --el-color-primary: #5b6472;
+  --el-color-primary-light-1: #6b7583;
+  --el-color-primary-light-3: #8a93a0;
+  --el-color-primary-light-5: #c7ccd3;
+  --el-color-primary-light-7: #e6e9ed;
+  --el-color-primary-light-8: #eff1f4;
+  --el-color-primary-light-9: #f7f8fa;
+  --el-color-primary-dark-2: #3c475b;
+
+  /* 颜色语义 */
+  --color-bg-primary: var(--color-white);
+  --color-bg-secondary: var(--gray-50);
+  --color-bg-muted: var(--gray-100);
+  --color-bg-card: var(--color-white);
+  --color-bg-page: var(--gray-75);
+
+  --color-text-primary: var(--gray-800);
+  --color-text-secondary: var(--gray-500);
+  --color-text-muted: var(--gray-400);
+  --color-text-inverse: var(--color-white);
+  --color-text-price: var(--color-text-primary);
+
+  --color-border-default: var(--gray-300);
+  --color-border-strong: var(--gray-400);
+  --color-border-subtle: var(--gray-200);
+  --color-border-hover: var(--gray-400);
+
+  --color-surface-hover: var(--gray-50);
+  --color-selected-bg: var(--gray-100);
+  --color-selected-border: var(--gray-300);
+
+  --color-focus-ring: var(--gray-500-10);
+
+  --color-danger: var(--red-600);
+  --color-danger-hover: var(--red-700);
+  --color-success: var(--green-500);
+  --color-warning: var(--amber-500);
+  --color-info: var(--cyan-500);
+
+  --bg-base: var(--color-bg-card);
+  --bg-secondary: var(--color-bg-secondary);
+  --bg-hover: var(--color-surface-hover);
+  --bg-active: var(--color-selected-bg);
+  --bg-disabled: var(--gray-200);
+
+  --border-default: var(--color-border-default);
+  --border-dark: var(--color-border-strong);
+  --border-light: var(--color-border-subtle);
+
+  --text-primary: var(--color-text-primary);
+  --text-secondary: var(--color-text-secondary);
+  --text-tertiary: var(--color-text-muted);
+  --text-muted: var(--color-text-muted);
+  --text-disabled: var(--gray-400);
+  --text-inverse: var(--color-text-inverse);
+  --text-price: var(--color-text-primary);
+
+  --link-color: var(--brand-primary);
+  --link-hover-color: var(--brand-primary-hover);
+  --link-visited: var(--brand-primary-active);
   --link-disabled: var(--color-text-secondary);
 
-  /* 反馈语义（soft 背景 + 边框，避免强色块） */
-  --color-success: #16a34a;
   --success-soft-bg: #ecfdf5;
   --success-border: #bbf7d0;
-
-  --color-warning: #f59e0b;
   --warning-soft-bg: #fffbeb;
   --warning-border: #fde68a;
-
-  --color-danger: #dc2626;
   --danger-soft-bg: #fef2f2;
   --danger-border: #fecaca;
-
-  --color-info: #0ea5e9;
   --info-soft-bg: #f0f9ff;
   --info-border: #bae6fd;
 
-  /* 收藏（Favorite）三态 */
+  --surface-2: #f5f5f5;
+  --surface-3: #f0f2f5;
+  --surface-4: #e8e8e8;
+
   --favorite-icon-default: var(--color-text-secondary);
   --favorite-icon-hover: var(--color-text-primary);
-  --favorite-icon-active: var(--juwo-primary);
+  --favorite-icon-active: var(--brand-primary);
 
-  /* 徽标/计数（Pill/Badge） */
-  --badge-bg: var(--chip-bg);
-  --badge-fg: var(--color-text-secondary);
-  --badge-border: var(--color-border-default);
-
-  /* 分隔线 */
   --divider-color: var(--color-border-default);
 
-  /* 品牌别名（统一入口） */
-  --brand-primary: var(--juwo-primary);
+  /* 字体与排印 */
+  --font-family-zh-sans: var(--font-zh-base);
+  --font-family-en-sans: var(--font-en-base);
+  --font-system: var(--font-system-base);
+  --font-numeric-variant: tabular-nums;
+
+  --font-weight-regular: var(--weight-regular);
+  --font-weight-medium: var(--weight-medium);
+  --font-weight-semibold: var(--weight-semibold);
+  --font-weight-bold: var(--weight-bold);
+
+  --line-height-tight: var(--leading-tight);
+  --line-height-normal: var(--leading-normal);
+  --line-height-relaxed: var(--leading-relaxed);
+  --line-height-loose: var(--leading-loose);
+
+  --font-size-2xs: var(--size-11);
+  --font-size-xs: var(--size-12);
+  --font-size-sm: var(--size-13);
+  --font-size-md: var(--size-14);
+  --font-size-lg: var(--size-16);
+  --font-size-xl: var(--size-18);
+  --font-size-2xl: var(--size-20);
+  --font-size-3xl: var(--size-24);
+  --font-size-4xl: var(--size-32);
+
+  --text-xs: var(--font-size-xs);
+  --text-sm: var(--font-size-md);
+  --text-base: var(--font-size-lg);
+  --text-lg: var(--size-18);
+  --text-xl: var(--size-20);
+  --text-3xl: var(--size-32);
+  --text-4xl: 40px;
+
+  /* 间距语义（通用） */
+  --space-2xs: var(--size-4);
+  --space-xs: var(--size-6);
+  --space-sm: var(--size-8);
+  --space-md: var(--size-12);
+  --space-lg: var(--size-16);
+  --space-xl: var(--size-20);
+  --space-2xl: var(--size-24);
+  --space-3xl: var(--size-32);
+  --space-4xl: var(--size-48);
+
+  --space-1: var(--size-4);
+  --space-2: var(--size-8);
+  --space-3: var(--size-12);
+  --space-4: var(--size-16);
+  --space-6: var(--size-24);
+  --space-8: var(--size-32);
+  --space-12: var(--size-48);
+  --space-1-5: var(--size-6);
+  --space-3-5: var(--size-14);
+
+  --gap-xs: var(--space-xs);
+  --gap-lg: var(--space-lg);
+
+  /* 圆角语义 */
+  --radius-none: 0;
+  --radius-2xs: var(--size-2);
+  --radius-xs: var(--size-4);
+  --radius-compact-sm: var(--size-6);
+  --radius-sm: var(--size-8);
+  --radius-md: var(--size-12);
+  --radius-lg: var(--size-16);
+  --radius-xl: var(--size-20);
+  --radius-full: 9999px;
+
+  /* 投影 */
+  --shadow-xs: var(--shadow-100);
+  --shadow-sm: var(--shadow-100);
+  --shadow-md: var(--shadow-200);
+  --shadow-lg: var(--shadow-300);
+  --shadow-xl: var(--shadow-400);
+  --shadow-button: var(--shadow-200);
+  --shadow-focus: 0 0 0 3px var(--color-focus-ring);
+
+  /* 过渡与动效 */
+  --transition-fast: all var(--duration-150) ease;
+  --transition-normal: all var(--duration-200) ease;
+  --transition-slow: all var(--duration-300) ease;
+  --transition-all: var(--transition-normal);
+  --transition-colors: color var(--duration-150) ease,
+    background-color var(--duration-150) ease,
+    border-color var(--duration-150) ease;
+  --motion-fast: var(--duration-120);
+  --motion-base: var(--duration-180);
+
+  /* 高度、宽度、组件基线 */
+  --height-button: var(--size-40);
+  --height-input: var(--size-44);
+  --card-content-w: var(--size-580);
+  --bottom-nav-height: var(--size-56);
+
+  --neutral-scrollbar-color: #c0c4cc;
+  --neutral-scrollbar-hover-color: #909399;
+
+  --overlay-light-90: var(--overlay-white-90);
+  --overlay-dark-75: var(--overlay-black-75);
+
+  --brand-google: #ea4335;
+  --brand-facebook: #1877f2;
+
+  --status-success: var(--color-success);
+  --status-warning: var(--color-warning);
+  --status-error: var(--color-danger);
+  --status-info: var(--color-info);
+
+  --focus-ring-color: var(--color-focus-ring);
+  --focus-ring-width: 3px;
+}
+
+:root {
+  /* ---------------------------------------------------------------------- */
+  /* Tier 3 · Component Tokens (组件令牌：引用语义令牌)                     */
+  /* ---------------------------------------------------------------------- */
+
+  /* 基础按钮 */
+  --button-gap: var(--space-sm);
+  --button-padding-x: var(--space-lg);
+  --button-padding-y: var(--space-sm);
+  --button-font-size: var(--font-size-md);
+  --button-font-weight: var(--font-weight-medium);
+  --button-radius: var(--radius-md);
+
+  --button-primary-bg: var(--brand-primary);
+  --button-primary-color: var(--color-text-inverse);
+  --button-primary-hover-bg: var(--brand-primary-hover);
+  --button-primary-active-bg: var(--brand-primary-active);
+
+  --button-secondary-bg: var(--color-bg-primary);
+  --button-secondary-color: var(--color-text-secondary);
+  --button-secondary-border: var(--color-border-default);
+  --button-secondary-hover-bg: var(--color-surface-hover);
+  --button-secondary-hover-border: var(--color-border-strong);
+  --button-secondary-hover-color: var(--color-text-primary);
+
+  --button-danger-bg: var(--color-danger);
+  --button-danger-hover-bg: var(--color-danger-hover);
+
+  /* 筛选 Chip */
+  --chip-gap: var(--space-sm);
+  --chip-padding-x: 10px;
+  --chip-padding-y: 6px;
+  --chip-border: var(--color-border-default);
+  --chip-radius: var(--radius-xs);
+  --chip-bg: var(--color-bg-secondary);
+  --chip-hover-bg: var(--color-bg-muted);
+  --chip-hover-border: var(--color-border-strong);
+  --chip-text: var(--color-text-primary);
+  --chip-font-size: var(--font-size-sm);
+  --chip-font-weight: var(--font-weight-medium);
+
+  --chip-remove-size: var(--size-16);
+  --chip-remove-bg: var(--gray-200);
+  --chip-remove-color: var(--color-text-secondary);
+  --chip-remove-hover-bg: var(--color-danger);
+  --chip-remove-hover-color: var(--color-text-inverse);
+  --chip-remove-radius: var(--radius-2xs);
+
+  /* 搜索输入 */
+  --search-padding-x: var(--space-lg);
+  --search-padding-y: var(--space-md);
+  --search-padding-left: var(--size-40);
+  --search-font-size: var(--font-size-md);
+  --search-radius: var(--radius-compact-sm);
+  --search-border: var(--color-border-default);
+  --search-focus-border: var(--color-text-secondary);
+  --search-hover-border: var(--color-border-strong);
+  --search-icon-left: var(--space-md);
+  --search-icon-size: var(--size-16);
+  --search-icon-color: var(--color-text-secondary);
+  --search-clear-right: var(--space-sm);
+  --search-clear-size: var(--size-14);
+  --search-clear-padding: var(--space-2xs);
+  --search-clear-radius: var(--radius-xs);
+  --search-clear-hover-bg: var(--color-bg-muted);
+
+  --search-suffix-right: var(--space-md);
+  --search-suffix-hit: var(--size-28);
+
+  /* 按钮/输入尺寸（筛选字段） */
+  --filter-field-height-pc: var(--size-40);
+  --filter-field-height-mob: var(--size-44);
+  --filter-field-font-pc: var(--font-size-md);
+  --filter-field-font-mob: var(--font-size-lg);
+  --filter-field-padding-x: var(--space-md);
+
+  /* 列表项 */
+  --list-item-padding-x: var(--space-lg);
+  --list-item-padding-y: 14px;
+  --list-item-min-height: 48px;
+  --list-item-border: var(--color-border-subtle);
+  --list-item-hover-bg: var(--color-surface-hover);
+  --list-item-selected-bg: var(--color-selected-bg);
+  --list-item-selected-border: var(--color-selected-border);
+
+  /* 面板结构 */
+  --panel-bg: var(--color-bg-primary);
+  --panel-radius: var(--radius-sm);
+  --panel-padding: var(--space-lg);
+  --panel-header-border: var(--color-border-default);
+  --panel-footer-border: var(--color-border-default);
+
+  --panel-title-font-size: var(--font-size-lg);
+  --panel-title-font-weight: var(--font-weight-semibold);
+  --panel-title-color: var(--color-text-primary);
+
+  --panel-close-size: var(--size-20);
+  --panel-close-padding: var(--space-2xs);
+  --panel-close-radius: var(--radius-xs);
+  --panel-close-color: var(--color-text-secondary);
+  --panel-close-hover-bg: var(--color-surface-hover);
+  --panel-close-hover-color: var(--color-text-primary);
+
+  --panel-empty-bg: var(--color-bg-secondary);
+  --panel-empty-border: var(--color-border-subtle);
+  --panel-empty-radius: var(--radius-sm);
+  --panel-empty-padding-x: var(--space-lg);
+  --panel-empty-padding-y: var(--space-xl);
+  --panel-empty-text-color: var(--color-text-secondary);
+  --panel-empty-font-size: var(--font-size-md);
+  --panel-empty-font-weight: var(--font-weight-medium);
+
+  --panel-group-bg: var(--color-bg-secondary);
+  --panel-group-padding-x: var(--space-lg);
+  --panel-group-padding-y: var(--space-sm);
+  --panel-group-font-size: var(--font-size-sm);
+  --panel-group-font-weight: var(--font-weight-semibold);
+  --panel-group-color: var(--color-text-primary);
+  --panel-group-border: var(--color-border-subtle);
+
+  --panel-action-link-color: var(--color-text-secondary);
+  --panel-action-link-font-size: var(--font-size-sm);
+  --panel-action-link-font-weight: var(--font-weight-medium);
+  --panel-action-link-padding-x: var(--space-md);
+  --panel-action-link-padding-y: var(--space-xs);
+  --panel-action-link-radius: var(--radius-compact-sm);
+  --panel-action-link-hover-bg: var(--color-surface-hover);
+  --panel-action-link-hover-color: var(--color-text-primary);
+
+  /* 复选框 */
+  --checkbox-size: 18px;
+  --checkbox-radius: var(--size-3);
+  --checkbox-accent: var(--color-text-secondary);
+
+  /* 行为链接/清除按钮 */
+  --clear-btn-right: var(--space-sm);
+  --clear-btn-size: var(--size-14);
+  --clear-btn-padding: var(--space-2xs);
+  --clear-btn-radius: var(--radius-xs);
+  --clear-btn-hover-bg: var(--color-bg-muted);
+
+  /* 区域选择器 */
+  --areas-body-max-height: var(--size-280);
+  --areas-body-radius: var(--radius-compact-sm);
+  --areas-body-bg: var(--color-bg-primary);
+  --areas-state-padding-x: var(--space-lg);
+  --areas-state-padding-y: var(--space-xl);
+  --areas-state-font-size: var(--font-size-md);
+  --areas-state-radius: var(--radius-compact-sm);
+  --areas-row-gap: var(--space-md);
+  --areas-row-padding-x: var(--space-lg);
+  --areas-row-padding-y: var(--space-3-5);
+  --areas-row-min-height: var(--space-12);
+  --areas-name-font-size: var(--font-size-md);
+  --areas-name-line-height: var(--line-height-normal);
+  --areas-name-font-weight-selected: var(--font-weight-semibold);
+
+  /* 阴影与焦点 */
+  --focus-shadow: var(--shadow-focus);
 }

--- a/vue-frontend/src/styles/page-tokens.css
+++ b/vue-frontend/src/styles/page-tokens.css
@@ -7,16 +7,15 @@
 :root {
   /* ===== 页面结构尺寸 =====
      中文注释：页面两端留白与区块间距统一，避免每页各写各的 margin/padding */
-  --header-height: 56px;            /* 顶部区域（移动端导航/标题区）统一高度参考 */
-  --bottom-nav-height: 56px;        /* 底部导航高度，用于页面 padding-bottom 防遮挡 */
+  --header-height: var(--size-56);            /* 顶部区域统一高度参考 */
 
   /* 左右内边距（移动/桌面分离），前端表现：页面根容器左右留白一致 */
-  --page-x-padding-mob: 16px;
-  --page-x-padding-desktop: 32px;
+  --page-x-padding-mob: var(--space-lg);
+  --page-x-padding-desktop: var(--space-3xl);
 
   /* 页面主区块纵向间距（大节奏），不与组件内部 spacing 冲突 */
-  --page-section-gap: var(--space-6, 24px);
-  --page-section-gap-lg: var(--space-8, 32px);
+  --page-section-gap: var(--space-6);
+  --page-section-gap-lg: var(--space-8);
 
   /* ===== 响应式断点（语义化，仅作参考，不强制使用） ===== */
   --bp-mob: 767px;
@@ -25,9 +24,8 @@
 
   /* ===== 动效节奏（统一时长与缓动） =====
      中文注释：用于 hover/展开/收起等交互，保持全站一致的运动语言 */
-  --motion-fast: 120ms;
-  --motion-base: 180ms;
-  --easing-standard: cubic-bezier(0.2, 0, 0, 1);
+  --motion-fast: var(--duration-120);
+  --motion-base: var(--duration-180);
 
   /* ===== 导航（Navigation）语义令牌 =====
      中文注释：统一导航高度/间距/图标尺寸/安全区，移动端底栏与顶部可共享 */
@@ -35,8 +33,8 @@
   --nav-h-desk: 64px;              /* 桌面端顶部导航目标高度 */
   --nav-px-mob: 16px;              /* 移动端导航左右内边距 */
   --nav-px-desk: 32px;             /* 桌面端导航左右内边距 */
-  --nav-gap: 24px;                 /* 导航项水平间距 */
-  --nav-icon: 16px;                /* 导航图标尺寸（宽高一致） */
+  --nav-gap: var(--space-lg);      /* 导航项水平间距 */
+  --nav-icon: var(--size-16);      /* 导航图标尺寸（宽高一致） */
   --nav-active-underline: 2px;     /* 活动态下划线厚度 */
   --nav-shadow: none;              /* 导航阴影开关（none 或设计系统阴影变量） */
   --nav-safe-area-bottom: env(safe-area-inset-bottom, 0px); /* iOS 安全区 */
@@ -45,13 +43,13 @@
      中文注释：仅样式接线，不改变交互逻辑 */
   --search-h-mob: 44px;            /* 移动/桌面统一 44，移动如需更高可覆盖 */
   --search-h-desk: 44px;
-  --search-radius: 6px;
-  --search-padding-x: 12px;
-  --search-icon: 16px;
-  --search-chip-radius: 16px;
-  --search-chip-gap: 8px;
-  --search-suffix-right: 12px;     /* 输入框右侧图标/点击区右边距 */
-  --search-suffix-hit: 32px;       /* 右侧后缀命中区域（可点面积） */
+  --search-radius: var(--radius-sm);
+  --search-padding-x: var(--space-md);
+  --search-icon: var(--size-16);
+  --search-chip-radius: var(--radius-xl);
+  --search-chip-gap: var(--space-sm);
+  --search-suffix-right: var(--space-md); /* 输入框右侧图标/点击区右边距 */
+  --search-suffix-hit: var(--space-3xl);   /* 右侧后缀命中区域（可点面积） */
 
   /* 滚动条宽度令牌：统一 PC 端滚动条宽度，便于对齐补偿 */
   --scrollbar-w: 8px;

--- a/vue-frontend/src/styles/typography.css
+++ b/vue-frontend/src/styles/typography.css
@@ -3,26 +3,6 @@
 */
 
 :root {
-  /* 基础字体家族（与现有别名互为映射，不破坏旧变量） */
-  --font-family-zh-sans: var(
-    --font-chinese,
-    'PingFang SC',
-    'Noto Sans SC',
-    'Source Han Sans SC',
-    'Microsoft YaHei',
-    system-ui,
-    sans-serif
-  );
-  --font-family-en-sans: var(
-    --font-english,
-    'Inter',
-    'SF Pro Text',
-    'Segoe UI',
-    Roboto,
-    system-ui,
-    sans-serif
-  );
-
   /* 8pt 字号尺度 */
   --font-size-xs: 12px;
   --font-size-sm: 14px;

--- a/vue-frontend/src/views/ChatView.vue
+++ b/vue-frontend/src/views/ChatView.vue
@@ -82,7 +82,7 @@ const goToHome = () => {
 }
 
 .placeholder-icon {
-  color: var(--filter-color-neutral-300);
+  color: var(--gray-300);
 }
 
 .placeholder-content h3 {

--- a/vue-frontend/src/views/CommuteTimes.vue
+++ b/vue-frontend/src/views/CommuteTimes.vue
@@ -514,10 +514,10 @@ onMounted(() => {
 .add-location-btn {
   width: 100%;
   height: 48px;
-  border: 1px solid var(--filter-btn-secondary-border); /* 中文注释：统一走次要按钮描边令牌，移除硬编码红色 */
+  border: 1px solid var(--button-secondary-border); /* 中文注释：统一走次要按钮描边令牌，移除硬编码红色 */
   border-radius: 8px;
-  background: var(--filter-btn-secondary-bg); /* 中文注释：次要按钮默认白底，令牌可全局切换 */
-  color: var(--filter-btn-secondary-color); /* 中文注释：文字/图标颜色走次要按钮令牌 */
+  background: var(--button-secondary-bg); /* 中文注释：次要按钮默认白底，令牌可全局切换 */
+  color: var(--button-secondary-color); /* 中文注释：文字/图标颜色走次要按钮令牌 */
   font-size: 16px;
   font-weight: 600;
   cursor: pointer;
@@ -525,20 +525,20 @@ onMounted(() => {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  transition: all var(--filter-transition-normal); /* 中文注释：统一过渡令牌 */
+  transition: all var(--transition-normal); /* 中文注释：统一过渡令牌 */
   margin-top: auto;
 }
 
 .add-location-btn:hover {
   /* 中文注释：悬浮态使用统一弱底与加深描边/文字，避免危险色误导 */
-  background: var(--filter-color-hover-bg);
-  border-color: var(--filter-btn-secondary-hover-border);
-  color: var(--filter-btn-secondary-hover-color);
+  background: var(--color-surface-hover);
+  border-color: var(--button-secondary-hover-border);
+  color: var(--button-secondary-hover-color);
 }
 
 .add-location-btn:focus-visible {
   /* 中文注释：键盘可达性——轻微灰色焦点环，使用设计令牌 */
-  box-shadow: var(--filter-shadow-focus);
+  box-shadow: var(--shadow-focus);
 }
 
 .add-location-btn:active {

--- a/vue-frontend/src/views/Favorites.vue
+++ b/vue-frontend/src/views/Favorites.vue
@@ -142,7 +142,7 @@ const handleContactProperty = (property) => {
 }
 
 .empty-icon-symbol {
-  color: var(--filter-color-neutral-300);
+  color: var(--gray-300);
 }
 
 .empty-state h3 {

--- a/vue-frontend/src/views/MapView.vue
+++ b/vue-frontend/src/views/MapView.vue
@@ -82,7 +82,7 @@ const goToHome = () => {
 }
 
 .placeholder-icon {
-  color: var(--filter-color-neutral-300);
+  color: var(--gray-300);
 }
 
 .placeholder-content h3 {


### PR DESCRIPTION
**Summary**
* Rebuilt `vue-frontend/src/styles/design-tokens.css` into a three-tier structure (primitives, semantic, component tokens), converting former `--filter-*` globals to shared tokens like `--color-*`, `--space-*`, and defining component tokens such as `--button-*`, `--panel-*`, and `--search-*`.
* Updated the design-system docs to reflect the new naming (no more blanket `--filter-*` guidance).
* Refactored all components/styles that referenced the old tokens so they now consume the new shared names (buttons use `--button-*`, chips use `--chip-*`, panels use `--panel-*`, etc.).
* Adjusted page-level tokens to draw from the new spacing/radius primitives instead of re-declaring raw values.
* Trimmed typography setup to rely on the new font-family semantics declared in design-tokens.
* Normalized the Areas selector so its spacing, radii, and typography all read from the new component tokens and a `--size-280` primitive rather than hard-coded pixel values.
* Ran `npm run lint` (passed with no changes).

**Outstanding TODOs**
1. Double-check other CSS/MD docs for lingering references to `--filter-*` (should only remain for `--filter-field-*` inputs).
2. Ensure no regressions in V2 filter wizard when it’s enabled, since the refactor touched the underlying tokens it consumes.

**Testing**
* ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e178793ce0832aaad3c173c0126fc7