### PR TITLE
feat: systematize typography and localize property card

### DIFF
--- a/vue-frontend/src/components/PropertyCard.vue
+++ b/vue-frontend/src/components/PropertyCard.vue
@@ -31,14 +31,14 @@
       />
 
       <!-- 图片计数器 (仅多图片时显示) -->
-      <div v-if="validImages.length > 1" class="image-counter">
+      <div v-if="validImages.length > 1" class="image-counter typo-meta">
         {{ currentImageIndex + 1 }} / {{ validImages.length }}
       </div>
 
       <!-- 移除图片上的按钮 -->
 
       <!-- 新房源标签 -->
-      <div v-if="isNewProperty" class="property-status-tag typo-label">
+      <div v-if="isNewProperty" class="property-status-tag typo-badge">
         {{ $t('propertyCard.newBadge') }}
       </div>
     </div>
@@ -49,7 +49,7 @@
       <div class="property-header">
         <div class="property-price english-text typo-price">
           {{ formatPrice(property.rent_pw) }}
-          <span class="price-unit typo-label">{{ $t('propertyCard.perWeek') }}</span>
+          <span class="price-unit typo-price-unit">{{ $t('propertyCard.perWeek') }}</span>
         </div>
         <div class="property-actions">
           <!-- 收藏按钮 -->
@@ -75,7 +75,7 @@
                 <el-dropdown-item command="hide">
                   <EyeOff class="spec-icon" />
                   <span class="typo-body-sm">{{ $t('propertyCard.hide') }}</span>
-                  <div class="typo-body-sm text-xs text-secondary" style="margin-left: 24px">
+                  <div class="typo-body-xs text-secondary" style="margin-left: 24px">
                     {{ $t('propertyCard.hideHint') }}
                   </div>
                 </el-dropdown-item>
@@ -86,24 +86,28 @@
       </div>
 
       <!-- 地址信息 - 两行显示，保持英文 -->
-      <div class="property-address english-text">
-        <div class="property-address-primary">{{ streetAddress }},</div>
-        <div class="property-address-secondary">{{ locationInfo }}</div>
+      <div class="property-address">
+        <div class="property-address-primary english-text typo-address">
+          {{ streetAddress }},
+        </div>
+        <div class="property-address-secondary english-text typo-address-secondary">
+          {{ locationInfo }}
+        </div>
       </div>
 
       <!-- 房型信息 - Lucide 图标 + 数字 -->
       <div class="property-features spec-row">
         <div class="feature-item spec-item">
           <BedDouble class="spec-icon" />
-          <span class="spec-text">{{ property.bedrooms || 0 }}</span>
+          <span class="spec-text typo-metric">{{ property.bedrooms || 0 }}</span>
         </div>
         <div class="feature-item spec-item">
           <Bath class="spec-icon" />
-          <span class="spec-text">{{ property.bathrooms || 0 }}</span>
+          <span class="spec-text typo-metric">{{ property.bathrooms || 0 }}</span>
         </div>
         <div class="feature-item spec-item">
           <CarFront class="spec-icon" />
-          <span class="spec-text">{{ property.parking_spaces || 0 }}</span>
+          <span class="spec-text typo-metric">{{ property.parking_spaces || 0 }}</span>
         </div>
       </div>
 
@@ -186,12 +190,14 @@ const validImages = computed(() => {
 const placeholderImage = computed(() => {
   const background = getCssVarValue('--gray-100', '#f3f4f6')
   const foreground = getCssVarValue('--gray-400', '#9ca3af')
-  const placeholderSvg = `<svg width="580" height="386" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="${background}"/><text x="50%" y="50%" font-family="Inter, sans-serif" font-size="18" dy=".3em" fill="${foreground}" text-anchor="middle">${t('propertyCard.imageAlt')}</text></svg>`
+  const fontFamily = getCssVarValue('--font-family-en-sans', 'Inter, sans-serif')
+  const fontSize = getCssVarValue('--font-size-lg', '18px')
+  const placeholderSvg = `<svg width="580" height="386" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="${background}"/><text x="50%" y="50%" font-family="${fontFamily}" font-size="${fontSize}" dy=".3em" fill="${foreground}" text-anchor="middle">${t('propertyCard.imageAlt')}</text></svg>`
   return `data:image/svg+xml,${encodeURIComponent(placeholderSvg)}`
 })
 
 const streetAddress = computed(() => {
-  if (!props.property.address) return '地址未知'
+  if (!props.property.address) return t('propertyCard.unknownAddress')
   const addressParts = props.property.address.split(',')
   return addressParts[0]?.trim() || props.property.address
 })
@@ -230,13 +236,13 @@ const formatPrice = (price) => {
 }
 
 const formatAvailabilityDate = (dateString) => {
-  if (!dateString) return '立即入住'
+  if (!dateString) return t('propertyCard.availableNow')
 
   const availDate = new Date(dateString)
   const today = new Date()
 
   if (availDate <= today) {
-    return '立即入住'
+    return t('propertyCard.availableNow')
   }
 
   // 格式化为中文日期
@@ -244,7 +250,7 @@ const formatAvailabilityDate = (dateString) => {
   const month = availDate.getMonth() + 1
   const day = availDate.getDate()
 
-  return `${year}年${month}月${day}日`
+  return t('propertyCard.availableDateFormat', { year, month, day })
 }
 
 const formatInspectionTime = (timeString) => {
@@ -302,11 +308,11 @@ const handleMoreAction = (command) => {
     // 实现分享功能
     const shareUrl = `${window.location.origin}/property/${props.property.listing_id}`
     navigator.clipboard.writeText(shareUrl)
-    ElMessage.success('链接已复制到剪贴板')
+    ElMessage.success(t('propertyCard.shareCopied'))
   } else if (command === 'hide') {
     // 实现隐藏功能
     propertiesStore.hideProperty(props.property.listing_id)
-    ElMessage.info('已从搜索结果中移除')
+    ElMessage.info(t('propertyCard.hideSuccess'))
   }
 }
 </script>
@@ -358,7 +364,7 @@ const handleMoreAction = (command) => {
   color: var(--color-text-inverse) !important; /* 中文注释：使用反色文本令牌，替代命名色 white */
   width: 40px !important;
   height: 60px !important;
-  font-size: 24px !important;
+  font-size: var(--size-24) !important;
   opacity: 0.7;
   transition: opacity 0.3s ease !important;
   border: none !important;
@@ -406,8 +412,6 @@ const handleMoreAction = (command) => {
   left: 12px;
   background: var(--overlay-dark-75);
   color: var(--color-text-inverse); /* 中文注释：反色文本令牌，便于主题切换与高对比 */
-  font-size: 11px;
-  font-weight: 400;
   padding: 3px 8px;
   border-radius: 4px;
   z-index: 10;
@@ -473,12 +477,8 @@ const handleMoreAction = (command) => {
   left: 12px;
   background: var(--brand-primary); /* 中文注释：改为品牌蓝，符合“新上线”品牌语义；可统一全站主题 */
   color: var(--color-text-inverse); /* 中文注释：文本走反色令牌，确保可读性与高对比模式 */
-  font-size: 10px;
-  font-weight: 600;
   padding: 4px 10px;
   border-radius: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   z-index: 10;
 }
 
@@ -501,17 +501,12 @@ const handleMoreAction = (command) => {
 
 /* 价格显示 - 匹配现有设计 */
 .property-price {
-  font-size: 22px;
-  font-weight: 700;
   color: var(--color-text-primary);
-  line-height: 1.2;
   margin-bottom: 8px;
 }
 
 .price-unit {
-  font-size: 14px;
   color: var(--color-text-secondary);
-  font-weight: 400;
 }
 
 /* 地址信息 - 两行显示 */
@@ -520,18 +515,12 @@ const handleMoreAction = (command) => {
 }
 
 .property-address-primary {
-  font-size: 15px;
   color: var(--color-text-primary);
-  font-weight: 500;
-  line-height: 1.3;
   margin-bottom: 4px;
 }
 
 .property-address-secondary {
-  font-size: 13px;
   color: var(--color-text-secondary);
-  font-weight: 500;
-  line-height: 1.3;
 }
 
 /* 房型信息图标 - Lucide */
@@ -569,13 +558,10 @@ const handleMoreAction = (command) => {
 }
 
 .feature-item .spec-text {
-  line-height: 1; /* 数字与图标基线对齐，前端表现更稳 */
 }
 
 .feature-item span {
   color: var(--color-text-primary);
-  font-weight: 600;
-  font-size: 14px;
 }
 
 /* 底部信息区域 */
@@ -588,15 +574,11 @@ const handleMoreAction = (command) => {
 
 .availability-text {
   color: var(--color-text-secondary);
-  font-size: 13px;
-  font-weight: 400;
   margin-bottom: 4px;
 }
 
 .inspection-text {
   color: var(--link-color);
-  font-size: 12px;
-  font-weight: 500;
 }
 
 /* 响应式适配 */

--- a/vue-frontend/src/i18n/index.js
+++ b/vue-frontend/src/i18n/index.js
@@ -43,6 +43,15 @@ function isObject(val) {
   return val && typeof val === 'object' && !Array.isArray(val)
 }
 
+function formatMessage(value, params) {
+  if (typeof value !== 'string') return value
+  if (!params || typeof params !== 'object') return value
+  return Object.keys(params).reduce((acc, key) => {
+    const pattern = new RegExp(`\\{${key}\\}`, 'g')
+    return acc.replace(pattern, params[key])
+  }, value)
+}
+
 // 递归浅安全合并（右侧覆盖左侧），数组直接覆盖
 function deepMerge(target, source) {
   const out = isObject(target) ? { ...target } : {}
@@ -79,11 +88,11 @@ export default {
     }
 
     // t: 读取当前 locale 的文案，失败回退到 fallback，再回退 key
-    const t = (key) => {
+    const t = (key, params) => {
       const val = get(messages[locale], key)
-      if (val != null) return val
+      if (val != null) return formatMessage(val, params)
       const fb = get(messages[fallbackLocale], key)
-      return fb != null ? fb : key
+      return fb != null ? formatMessage(fb, params) : key
     }
 
     // 全局 $t，可直接在模板使用

--- a/vue-frontend/src/i18n/locales/zh-CN.js
+++ b/vue-frontend/src/i18n/locales/zh-CN.js
@@ -17,6 +17,11 @@ export default {
     priceTBA: '价格待定',
     availableDateLabel: '空出日期',
     inspectionTimeLabel: '开放时间',
+    availableNow: '立即入住',
+    availableDateFormat: '{year}年{month}月{day}日',
+    shareCopied: '链接已复制到剪贴板',
+    hideSuccess: '已从搜索结果中移除',
+    unknownAddress: '地址未知',
   },
   propertyDetail: {
     photos: '照片',

--- a/vue-frontend/src/styles/typography.css
+++ b/vue-frontend/src/styles/typography.css
@@ -1,87 +1,175 @@
-/* Typography Tokens & Utilities
-   中文注释：新增“文字系统”基础令牌与语义类。仅新增，不改动现有 tokens/样式，保证向后兼容。
-*/
+/**
+ * Typography Tokens & Utilities
+ * --------------------------------------------------------------------------
+ * 统一管理字体家族、字号、字重、行高与语义化文字角色。
+ * 所有尺寸均引用 design-tokens.css 中的单一事实来源，保持主题一致。
+ */
 
 :root {
-  /* 8pt 字号尺度 */
-  --font-size-xs: 12px;
-  --font-size-sm: 14px;
-  --font-size-md: 16px;
-  --font-size-lg: 20px;
-  --font-size-xl: 24px;
-  --font-size-xxl: 32px;
-  --font-size-3xl: 40px;
+  /* ---------------------------------------------------------------------- */
+  /* Tier 1 · Primitive Typography Tokens                                   */
+  /* ---------------------------------------------------------------------- */
+  --font-family-zh-sans: var(--font-zh-base);
+  --font-family-en-sans: var(--font-en-base);
 
-  /* 字重与行高 */
-  --font-weight-regular: 400;
-  --font-weight-medium: 500;
-  --font-weight-semibold: 600;
-  --font-weight-bold: 700;
+  /* 8pt 模度（继承自 size-* 原子尺寸） */
+  --font-size-2xs: var(--size-11);
+  --font-size-xs: var(--size-12);
+  --font-size-sm: var(--size-13);
+  --font-size-md: var(--size-14);
+  --font-size-lg: var(--size-16);
+  --font-size-xl: var(--size-18);
+  --font-size-2xl: var(--size-20);
+  --font-size-xxl: var(--size-32);
+  --font-size-3xl: var(--size-40);
 
-  --line-height-tight: 1.2;
-  --line-height-normal: 1.4;
-  --line-height-relaxed: 1.6;
-  --line-height-loose: 1.8;
+  --font-weight-regular: var(--weight-regular);
+  --font-weight-medium: var(--weight-medium);
+  --font-weight-semibold: var(--weight-semibold);
+  --font-weight-bold: var(--weight-bold);
 
-  /* 数字可读性（价格/计数） */
+  --line-height-tight: var(--leading-tight);
+  --line-height-normal: var(--leading-normal);
+  --line-height-relaxed: var(--leading-relaxed);
+  --line-height-loose: var(--leading-loose);
+
   --font-numeric-variant: tabular-nums;
 
-  /* 语义令牌（拆分到 size/weight/lineHeight/family，便于复用与定制） */
+  /* ---------------------------------------------------------------------- */
+  /* Tier 2 · Semantic Typography Tokens                                    */
+  /* ---------------------------------------------------------------------- */
   /* 正文 */
   --typography-body-default-size: var(--font-size-md);
   --typography-body-default-weight: var(--font-weight-regular);
   --typography-body-default-line: var(--line-height-relaxed);
   --typography-body-default-family: var(--font-family-zh-sans);
 
-  /* 小正文/辅助 */
+  --typography-body-strong-size: var(--font-size-md);
+  --typography-body-strong-weight: var(--font-weight-medium);
+  --typography-body-strong-line: var(--line-height-normal);
+  --typography-body-strong-family: var(--font-family-zh-sans);
+
   --typography-body-small-size: var(--font-size-sm);
   --typography-body-small-weight: var(--font-weight-regular);
   --typography-body-small-line: var(--line-height-normal);
   --typography-body-small-family: var(--font-family-zh-sans);
 
-  /* 页面主标题 */
-  --typography-heading-page-size: var(--font-size-xxl);
+  --typography-body-xs-size: var(--font-size-2xs);
+  --typography-body-xs-weight: var(--font-weight-regular);
+  --typography-body-xs-line: var(--line-height-normal);
+  --typography-body-xs-family: var(--font-family-zh-sans);
+
+  /* 标题 */
+  --typography-heading-page-size: var(--font-size-3xl);
   --typography-heading-page-weight: var(--font-weight-bold);
   --typography-heading-page-line: var(--line-height-tight);
   --typography-heading-page-family: var(--font-family-zh-sans);
 
-  /* 卡片标题 */
-  --typography-heading-card-size: var(--font-size-lg);
+  --typography-heading-section-size: var(--font-size-xxl);
+  --typography-heading-section-weight: var(--font-weight-bold);
+  --typography-heading-section-line: var(--line-height-tight);
+  --typography-heading-section-family: var(--font-family-zh-sans);
+
+  --typography-heading-card-size: var(--font-size-xl);
   --typography-heading-card-weight: var(--font-weight-semibold);
   --typography-heading-card-line: var(--line-height-normal);
   --typography-heading-card-family: var(--font-family-zh-sans);
 
-  /* 价格（沿用现有 22px，数值等宽） */
-  --typography-price-size: 22px;
-  --typography-price-weight: var(--font-weight-bold);
-  --typography-price-line: var(--line-height-tight);
-  --typography-price-family: var(--font-family-en-sans);
+  --typography-heading-sub-size: var(--font-size-lg);
+  --typography-heading-sub-weight: var(--font-weight-medium);
+  --typography-heading-sub-line: var(--line-height-normal);
+  --typography-heading-sub-family: var(--font-family-zh-sans);
 
-  /* 地址（英文主导） */
-  --typography-address-size: 15px;
-  --typography-address-weight: var(--font-weight-medium);
-  --typography-address-line: 1.3;
-  --typography-address-family: var(--font-family-en-sans);
+  /* 价格与数字 */
+  --typography-price-primary-size: var(--size-22);
+  --typography-price-primary-weight: var(--font-weight-bold);
+  --typography-price-primary-line: var(--line-height-tight);
+  --typography-price-primary-family: var(--font-family-en-sans);
 
-  /* 按钮 */
-  --typography-button-size: var(--font-size-md);
-  --typography-button-weight: var(--font-weight-medium);
-  --typography-button-line: var(--line-height-normal);
-  --typography-button-family: var(--font-family-zh-sans);
+  --typography-price-unit-size: var(--font-size-sm);
+  --typography-price-unit-weight: var(--font-weight-medium);
+  --typography-price-unit-line: var(--line-height-normal);
+  --typography-price-unit-family: var(--font-family-zh-sans);
 
-  /* 标签/单位（如“每周”） */
+  --typography-metric-size: var(--font-size-sm);
+  --typography-metric-weight: var(--font-weight-semibold);
+  --typography-metric-line: 1;
+  --typography-metric-family: var(--font-family-en-sans);
+
+  /* 地址 */
+  --typography-address-primary-size: var(--size-15);
+  --typography-address-primary-weight: var(--font-weight-medium);
+  --typography-address-primary-line: 1.3;
+  --typography-address-primary-family: var(--font-family-en-sans);
+
+  --typography-address-secondary-size: var(--font-size-sm);
+  --typography-address-secondary-weight: var(--font-weight-medium);
+  --typography-address-secondary-line: 1.3;
+  --typography-address-secondary-family: var(--font-family-en-sans);
+
+  /* 操作与状态 */
+  --typography-button-primary-size: var(--font-size-md);
+  --typography-button-primary-weight: var(--font-weight-medium);
+  --typography-button-primary-line: var(--line-height-normal);
+  --typography-button-primary-family: var(--font-family-zh-sans);
+
+  --typography-button-compact-size: var(--font-size-sm);
+  --typography-button-compact-weight: var(--font-weight-medium);
+  --typography-button-compact-line: var(--line-height-tight);
+  --typography-button-compact-family: var(--font-family-zh-sans);
+
   --typography-label-size: var(--font-size-sm);
   --typography-label-weight: var(--font-weight-regular);
   --typography-label-line: var(--line-height-normal);
   --typography-label-family: var(--font-family-zh-sans);
+
+  --typography-badge-size: var(--font-size-xs);
+  --typography-badge-weight: var(--font-weight-semibold);
+  --typography-badge-line: var(--line-height-tight);
+  --typography-badge-family: var(--font-family-zh-sans);
+
+  --typography-meta-size: var(--font-size-xs);
+  --typography-meta-weight: var(--font-weight-regular);
+  --typography-meta-line: var(--line-height-tight);
+  --typography-meta-family: var(--font-family-zh-sans);
 }
 
-/* 语义工具类（前端表现：给元素加类名即可获得统一排印风格） */
+/* ------------------------------------------------------------------------ */
+/* Tier 3 · Utility Classes                                                 */
+/* ------------------------------------------------------------------------ */
+.typo-body,
+.typo-body-strong,
+.typo-body-sm,
+.typo-body-xs,
+.typo-heading-page,
+.typo-heading-section,
+.typo-heading-card,
+.typo-heading-sub,
+.typo-price,
+.typo-price-unit,
+.typo-address,
+.typo-address-secondary,
+.typo-button,
+.typo-button-compact,
+.typo-label,
+.typo-badge,
+.typo-meta,
+.typo-metric {
+  font-feature-settings: 'kern' 1;
+}
+
 .typo-body {
   font-family: var(--typography-body-default-family);
   font-size: var(--typography-body-default-size);
   font-weight: var(--typography-body-default-weight);
   line-height: var(--typography-body-default-line);
+}
+
+.typo-body-strong {
+  font-family: var(--typography-body-strong-family);
+  font-size: var(--typography-body-strong-size);
+  font-weight: var(--typography-body-strong-weight);
+  line-height: var(--typography-body-strong-line);
 }
 
 .typo-body-sm {
@@ -91,11 +179,25 @@
   line-height: var(--typography-body-small-line);
 }
 
+.typo-body-xs {
+  font-family: var(--typography-body-xs-family);
+  font-size: var(--typography-body-xs-size);
+  font-weight: var(--typography-body-xs-weight);
+  line-height: var(--typography-body-xs-line);
+}
+
 .typo-heading-page {
   font-family: var(--typography-heading-page-family);
   font-size: var(--typography-heading-page-size);
   font-weight: var(--typography-heading-page-weight);
   line-height: var(--typography-heading-page-line);
+}
+
+.typo-heading-section {
+  font-family: var(--typography-heading-section-family);
+  font-size: var(--typography-heading-section-size);
+  font-weight: var(--typography-heading-section-weight);
+  line-height: var(--typography-heading-section-line);
 }
 
 .typo-heading-card {
@@ -105,26 +207,62 @@
   line-height: var(--typography-heading-card-line);
 }
 
+.typo-heading-sub {
+  font-family: var(--typography-heading-sub-family);
+  font-size: var(--typography-heading-sub-size);
+  font-weight: var(--typography-heading-sub-weight);
+  line-height: var(--typography-heading-sub-line);
+}
+
 .typo-price {
-  font-family: var(--typography-price-family);
-  font-size: var(--typography-price-size);
-  font-weight: var(--typography-price-weight);
-  line-height: var(--typography-price-line);
+  font-family: var(--typography-price-primary-family);
+  font-size: var(--typography-price-primary-size);
+  font-weight: var(--typography-price-primary-weight);
+  line-height: var(--typography-price-primary-line);
+  font-variant-numeric: var(--font-numeric-variant);
+}
+
+.typo-price-unit {
+  font-family: var(--typography-price-unit-family);
+  font-size: var(--typography-price-unit-size);
+  font-weight: var(--typography-price-unit-weight);
+  line-height: var(--typography-price-unit-line);
+}
+
+.typo-metric {
+  font-family: var(--typography-metric-family);
+  font-size: var(--typography-metric-size);
+  font-weight: var(--typography-metric-weight);
+  line-height: var(--typography-metric-line);
   font-variant-numeric: var(--font-numeric-variant);
 }
 
 .typo-address {
-  font-family: var(--typography-address-family);
-  font-size: var(--typography-address-size);
-  font-weight: var(--typography-address-weight);
-  line-height: var(--typography-address-line);
+  font-family: var(--typography-address-primary-family);
+  font-size: var(--typography-address-primary-size);
+  font-weight: var(--typography-address-primary-weight);
+  line-height: var(--typography-address-primary-line);
+}
+
+.typo-address-secondary {
+  font-family: var(--typography-address-secondary-family);
+  font-size: var(--typography-address-secondary-size);
+  font-weight: var(--typography-address-secondary-weight);
+  line-height: var(--typography-address-secondary-line);
 }
 
 .typo-button {
-  font-family: var(--typography-button-family);
-  font-size: var(--typography-button-size);
-  font-weight: var(--typography-button-weight);
-  line-height: var(--typography-button-line);
+  font-family: var(--typography-button-primary-family);
+  font-size: var(--typography-button-primary-size);
+  font-weight: var(--typography-button-primary-weight);
+  line-height: var(--typography-button-primary-line);
+}
+
+.typo-button-compact {
+  font-family: var(--typography-button-compact-family);
+  font-size: var(--typography-button-compact-size);
+  font-weight: var(--typography-button-compact-weight);
+  line-height: var(--typography-button-compact-line);
 }
 
 .typo-label {
@@ -134,10 +272,29 @@
   line-height: var(--typography-label-line);
 }
 
+.typo-badge {
+  font-family: var(--typography-badge-family);
+  font-size: var(--typography-badge-size);
+  font-weight: var(--typography-badge-weight);
+  line-height: var(--typography-badge-line);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.typo-meta {
+  font-family: var(--typography-meta-family);
+  font-size: var(--typography-meta-size);
+  font-weight: var(--typography-meta-weight);
+  line-height: var(--typography-meta-line);
+}
+
 /* 兼容现有 english-text/chinese-text（可与上面类并用） */
-.en-text {
+.en-text,
+.english-text {
   font-family: var(--font-family-en-sans);
 }
-.zh-text {
+
+.zh-text,
+.chinese-text {
   font-family: var(--font-family-zh-sans);
 }


### PR DESCRIPTION
## Summary
- define typography primitives and semantic roles in `src/styles/typography.css`
- extend lightweight i18n plugin with interpolation support and zh-CN messages
- refactor `PropertyCard.vue` to use typography utilities and localized copy

## Details
### 1. Typography token system (`src/styles/typography.css`)
- Primitive tokens unify font families, size scale, weights, and line-heights.
- Semantic tokens cover body, heading, price, address, button, label, badge, meta, and metric roles.
- Utility classes (`.typo-*`) map each semantic role to reusable font declarations.

### 2. i18n framework
- `src/i18n/index.js` gains a `formatMessage` helper so `$t()` supports simple interpolation.
- `src/i18n/locales/zh-CN.js` now houses property card copy including availability status and toast text.

### 3. PropertyCard.vue refactor
```diff
- <div class="property-address english-text">
-   <div class="property-address-primary">{{ streetAddress }},</div>
-   <div class="property-address-secondary">{{ locationInfo }}</div>
- </div>
+ <div class="property-address">
+   <div class="property-address-primary english-text typo-address">
+     {{ streetAddress }},
+   </div>
+   <div class="property-address-secondary english-text typo-address-secondary">
+     {{ locationInfo }}
+   </div>
+ </div>
```
- Pricing, badges, metrics, and meta hints now rely on `.typo-*` utilities.
- Availability and toast copy use `$t('propertyCard.*')` keys with interpolation for formatted dates.

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68e19f609c9c832aac5773a606c941f7