### PR TITLE
fix(frontend): align base components with design tokens

### DIFF
--- a/vue-frontend/src/styles/base-components.css
+++ b/vue-frontend/src/styles/base-components.css
@@ -16,9 +16,9 @@
   gap: var(--gap-xs);
   height: var(--height-button);
   padding: 0 var(--space-6);
-  font-family: var(--font-primary);
+  font-family: var(--font-system);
   font-size: var(--text-sm);
-  font-weight: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   line-height: 1;
   text-decoration: none;
   white-space: nowrap;
@@ -61,7 +61,7 @@
 
 /* 次要按钮 */
 .btn-secondary {
-  background: var(--bg-card);
+  background: var(--color-bg-card);
   color: var(--text-primary);
   border-color: var(--border-default);
 }
@@ -138,15 +138,15 @@
    ======================================== */
 
 .card {
-  background: var(--bg-card);
+  background: var(--color-bg-card);
   border-radius: var(--radius-md);
-  box-shadow: var(--shadow-card);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
   transition: var(--transition-all);
 }
 
 .card:hover {
-  box-shadow: var(--shadow-card-hover);
+  box-shadow: var(--shadow-lg);
   transform: translateY(-2px);
 }
 
@@ -173,10 +173,10 @@
   width: 100%;
   height: var(--height-input);
   padding: 0 var(--space-4);
-  font-family: var(--font-primary);
+  font-family: var(--font-system);
   font-size: var(--text-sm);
   color: var(--text-primary);
-  background: var(--bg-card);
+  background: var(--color-bg-card);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-sm);
   transition: var(--transition-colors);
@@ -211,7 +211,7 @@
 
 .input-label {
   font-size: var(--text-sm);
-  font-weight: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary);
 }
 
@@ -233,14 +233,14 @@
   display: inline-flex;
   align-items: baseline;
   gap: 2px;
-  font-weight: var(--font-bold);
+  font-weight: var(--font-weight-bold);
   color: var(--text-price);
   line-height: 1;
 }
 
 .price-symbol {
   font-size: 0.75em;
-  font-weight: var(--font-normal);
+  font-weight: var(--font-weight-regular);
   color: var(--text-secondary);
 }
 
@@ -250,7 +250,7 @@
 
 .price-unit {
   font-size: var(--text-sm);
-  font-weight: var(--font-normal);
+  font-weight: var(--font-weight-regular);
   color: var(--text-secondary);
   margin-left: var(--space-1);
 }
@@ -277,7 +277,7 @@
 
 .address-primary {
   font-size: var(--text-lg);
-  font-weight: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   color: var(--text-primary);
   line-height: var(--leading-tight);
 }
@@ -312,7 +312,7 @@
 
 .spec-value {
   font-size: var(--text-sm);
-  font-weight: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--text-primary);
 }
 
@@ -331,7 +331,7 @@
   gap: var(--gap-xs);
   padding: var(--space-1) var(--space-3);
   font-size: var(--text-xs);
-  font-weight: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   text-transform: uppercase;
   border-radius: var(--radius-full);
   transition: var(--transition-all);


### PR DESCRIPTION
## Summary
- swap base component font declarations to the shared system and weight tokens
- update card and input backgrounds/shadows to semantic design tokens for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e21620bd78832a87a53f31b2b60559